### PR TITLE
Release 0.2.0: delete/update API, CI, Python bindings, PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,140 @@
+name: Publish
+
+on:
+  # Release flow: push an annotated tag matching v*.*.*
+  #   git tag v0.2.0 && git push origin v0.2.0
+  push:
+    tags: ["v*"]
+  # Manual trigger lets you test the full wheel matrix (→ TestPyPI) without
+  # cutting a real release. Choose `testpypi_only` or `pypi` on the dispatch
+  # form; the default is TestPyPI so accidental runs never hit production.
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to upload"
+        required: true
+        default: "testpypi_only"
+        type: choice
+        options:
+          - testpypi_only
+          - pypi
+
+jobs:
+  # ── Build ────────────────────────────────────────────────────────
+  build_wheels:
+    name: Wheels ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-latest     → manylinux x86_64
+        # ubuntu-24.04-arm  → manylinux aarch64
+        # macos-13          → macOS x86_64 (Intel runner)
+        # macos-14          → macOS arm64 (Apple Silicon runner)
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error
+
+  build_sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: Verify sdist contents
+        run: |
+          echo "── sdist contents ──"
+          ls -la dist/
+          tar tzf dist/*.tar.gz | head -60
+          echo "── checking third_party/hnswlib is included ──"
+          tar tzf dist/*.tar.gz | grep hnswlib | head -5
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  # ── Publish: TestPyPI ────────────────────────────────────────────
+  # Runs for every tag push AND for manual dispatch. Acts as the
+  # mandatory pre-flight for the real PyPI upload.
+  publish_testpypi:
+    name: Upload to TestPyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/logosdb/
+    permissions:
+      id-token: write   # Trusted Publishing (OIDC)
+    steps:
+      - name: Download all artifacts into dist/
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # TestPyPI is noisy; skip silently if a file already exists for
+          # this version (e.g. re-running a tagged build).
+          skip-existing: true
+
+  # ── Publish: PyPI ────────────────────────────────────────────────
+  # Runs only when a version tag was pushed, OR when dispatched manually
+  # with target=pypi. The `environment: pypi` can be configured in the
+  # repo settings to require a reviewer before this job runs.
+  publish_pypi:
+    name: Upload to PyPI
+    needs: publish_testpypi
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    environment:
+      name: pypi
+      url: https://pypi.org/project/logosdb/
+    permissions:
+      id-token: write   # Trusted Publishing (OIDC)
+    steps:
+      - name: Download all artifacts into dist/
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,20 +1,14 @@
 logosdb change log
 ==================
 
-unreleased
-----------
+0.2.0  (2026-04-17)
+-------------------
 
-  * Added Python bindings (pybind11 + scikit-build-core). `pip install .`
-    builds a native extension that exposes logosdb.DB with put, search,
-    delete, update, count, count_live, dim, raw_vectors (zero-copy numpy
-    view) and logosdb.SearchHit. Smoke tests under tests/python/ and a
-    numpy/sentence-transformers example under examples/python/. A new
-    .github/workflows/python.yml job builds wheels and runs pytest on
-    Linux and macOS for Python 3.10 and 3.12.
-  * CMakeLists.txt gained LOGOSDB_BUILD_TOOLS, LOGOSDB_BUILD_TESTS, and
-    LOGOSDB_BUILD_PYTHON options so the Python wheel build skips CLI /
-    benchmark / C++ test targets. The static core library now builds with
-    position-independent code so it can be linked into the Python extension.
+  Highlights: first PyPI release with Python bindings, public delete/update
+  API, and CI across Linux and macOS.
+
+  Delete / update API (closes #3)
+
   * Added logosdb_delete(id) and logosdb_update(id, ...) to the public C API,
     with matching DB::del() and DB::update() on the C++ wrapper. Deletions
     are persisted as tombstone records in the JSONL metadata log and replayed
@@ -25,8 +19,38 @@ unreleased
     tombstoned rows) for storage-level introspection.
   * Metadata JSONL format now also carries tombstone records of the form
     {"op":"del","id":N}. Older data files remain readable.
-  * New tests cover delete/update/re-put, persistence across reopen, and
+  * New C++ tests cover delete/update/re-put, persistence across reopen, and
     tombstone replay after an index rebuild.
+
+  Python bindings and PyPI release (closes #4)
+
+  * Added Python bindings (pybind11 + scikit-build-core). pip install logosdb
+    installs a native extension that exposes logosdb.DB with put, search,
+    delete, update, count, count_live, dim, raw_vectors (zero-copy numpy
+    view) and logosdb.SearchHit. Smoke tests under tests/python/ and a
+    numpy/sentence-transformers example under examples/python/.
+  * CMakeLists.txt gained LOGOSDB_BUILD_TOOLS, LOGOSDB_BUILD_TESTS, and
+    LOGOSDB_BUILD_PYTHON options so the Python wheel build skips CLI /
+    benchmark / C++ test targets. The static core library now builds with
+    position-independent code so it can be linked into the Python extension.
+  * Added PyPI release plumbing: cibuildwheel configuration in
+    pyproject.toml and a .github/workflows/publish.yml workflow that, on
+    every v* tag, builds wheels for {Linux, macOS} x {x86_64, arm64} x
+    CPython {3.9..3.13}, builds the sdist, uploads everything to TestPyPI,
+    and finally to PyPI via Trusted Publishing (OIDC, no API tokens). A
+    RELEASING.md runbook documents the one-time Trusted Publisher setup
+    and the release flow.
+
+  CI and infrastructure (closes #1)
+
+  * New .github/workflows/ci.yml builds and tests on ubuntu-latest and
+    macos-latest in both Debug and Release via CMake + Ninja, runs ctest,
+    and smoke-tests the CLI. Build directory is cached across runs.
+  * New .github/workflows/python.yml builds the Python wheel and runs the
+    pytest smoke suite on Linux and macOS for CPython 3.10 and 3.12.
+  * Fixed a latent transitive-include bug in tools/logosdb-bench.cpp that
+    broke the build on Ubuntu's libstdc++ (std::partial_sort requires an
+    explicit <algorithm> include).
 
 0.1.0  (2025-06-25)
 -------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(logosdb VERSION 0.1.0 LANGUAGES CXX)
+project(logosdb VERSION 0.2.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![CI](https://github.com/jose-compu/logosdb/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jose-compu/logosdb/actions/workflows/ci.yml)
 [![Python](https://github.com/jose-compu/logosdb/actions/workflows/python.yml/badge.svg?branch=main)](https://github.com/jose-compu/logosdb/actions/workflows/python.yml)
+[![PyPI](https://img.shields.io/pypi/v/logosdb.svg)](https://pypi.org/project/logosdb/)
+[![Python versions](https://img.shields.io/pypi/pyversions/logosdb.svg)](https://pypi.org/project/logosdb/)
 
 LogosDB is a fast semantic vector database written in C/C++ that provides approximate nearest-neighbor search over embedding vectors with associated text metadata.
 
@@ -107,7 +109,13 @@ for (auto &r : results) {
 
 LogosDB ships Python bindings built with [pybind11](https://pybind11.readthedocs.io/) and [scikit-build-core](https://scikit-build-core.readthedocs.io/).
 
-Install:
+Install from PyPI (binary wheels provided for Linux x86_64/aarch64 and macOS x86_64/arm64 on CPython 3.9–3.13):
+
+```bash
+pip install logosdb
+```
+
+Or build from source in a clone:
 
 ```bash
 pip install .
@@ -169,7 +177,7 @@ Here is a performance report from the included `logosdb-bench` program. The resu
 
 We use databases with 1K, 10K, and 100K vectors. Each vector has 2048 dimensions (matching typical LLM embedding sizes). Vectors are L2-normalized random unit vectors.
 
-    LogosDB:    version 0.1.0
+    LogosDB:    version 0.2.0
     CPU:        Apple M-series (ARM64)
     Dim:        2048
     HNSW M:     16, ef_construction: 200, ef_search: 50

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,119 @@
+# Releasing `logosdb` to PyPI
+
+This repository publishes binary wheels (built with
+[`cibuildwheel`](https://cibuildwheel.pypa.io/)) and a source distribution
+to [PyPI](https://pypi.org/project/logosdb/) via GitHub Actions. Authentication
+uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+(OIDC), so no API tokens are stored anywhere.
+
+## One-time setup
+
+You need to do this **before** the first tag push succeeds. It takes ~5 min.
+
+### 1. Reserve the name on TestPyPI and PyPI
+
+- https://test.pypi.org/manage/account/publishing/
+- https://pypi.org/manage/account/publishing/
+
+On each site click *"Add a new pending publisher"* and fill in:
+
+| Field                     | Value                                  |
+|---------------------------|----------------------------------------|
+| PyPI Project Name         | `logosdb`                              |
+| Owner                     | `jose-compu`                           |
+| Repository name           | `logosdb`                              |
+| Workflow name             | `publish.yml`                          |
+| Environment name (PyPI)   | `pypi`                                 |
+| Environment name (TestPyPI) | `testpypi`                           |
+
+### 2. Create the two GitHub environments
+
+Go to `Settings → Environments → New environment` in the GitHub repo and create
+both `testpypi` and `pypi`. For `pypi` it is highly recommended to enable
+*"Required reviewers"* so a human has to approve the upload.
+
+That's it — the workflow already references these environments by name.
+
+## Cutting a release
+
+```bash
+# 1. Bump the version in both files. They MUST match.
+#    - pyproject.toml        → [project].version
+#    - include/logosdb/logosdb.h → LOGOSDB_VERSION_* and LOGOSDB_VERSION_STRING
+
+# 2. Update the CHANGELOG entry with the release date and notes.
+
+git add pyproject.toml include/logosdb/logosdb.h CHANGELOG
+git commit -m "Release v0.2.0"
+git push origin main
+
+# 3. Tag and push.
+git tag -a v0.2.0 -m "logosdb 0.2.0"
+git push origin v0.2.0
+```
+
+The tag push triggers `.github/workflows/publish.yml`:
+
+1. **`build_wheels`** runs on 4 runners (Linux x86_64, Linux arm64, macOS x86_64,
+   macOS arm64), invoking `cibuildwheel` to produce one wheel per supported
+   CPython version (3.9–3.13). Each wheel is tested against the pytest suite
+   inside the isolated build environment.
+2. **`build_sdist`** builds the source distribution.
+3. **`publish_testpypi`** uploads everything to TestPyPI.
+4. **`publish_pypi`** (waits for reviewer approval if configured) uploads the
+   same artifacts to PyPI.
+
+## Verifying a TestPyPI release before PyPI
+
+The `publish_pypi` job only runs after `publish_testpypi` finishes. If you've
+enabled *Required reviewers* on the `pypi` environment, GitHub will pause and
+request approval; use that window to spot-check TestPyPI:
+
+```bash
+python -m venv /tmp/v && . /tmp/v/bin/activate
+pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            logosdb==0.2.0
+python -c "
+import logosdb, numpy as np
+db = logosdb.DB('/tmp/smoke', dim=8)
+db.put(np.ones(8, dtype='f4'))
+print('ok:', db.count(), logosdb.__version__)
+"
+```
+
+If something looks wrong: decline the review in GitHub, delete the bad tag
+(`git tag -d v0.2.0 && git push --delete origin v0.2.0`), fix, and start over
+with a new version (`0.2.1`). PyPI *never* lets you re-upload the same version.
+
+## Manual dry-run (no tag)
+
+To exercise the full wheel matrix without publishing:
+
+```
+Actions → Publish → Run workflow → target: testpypi_only
+```
+
+This builds every wheel, uploads to TestPyPI, and stops. No PyPI upload.
+
+## Supported platforms
+
+- Linux x86_64  (manylinux2014-compatible)
+- Linux aarch64 (manylinux2014-compatible)
+- macOS 11+ x86_64
+- macOS 11+ arm64
+- CPython 3.9, 3.10, 3.11, 3.12, 3.13
+
+Windows is not yet supported; see
+[issue #10](https://github.com/jose-compu/logosdb/issues/10).
+
+## What an sdist user gets
+
+PyPI users on unsupported platforms (or with `--no-binary logosdb`) will fall
+back to the sdist, which requires:
+
+- CMake ≥ 3.15
+- A C++17 compiler
+- Python development headers
+
+The sdist includes `third_party/hnswlib/` so no submodules are needed.

--- a/include/logosdb/logosdb.h
+++ b/include/logosdb/logosdb.h
@@ -5,9 +5,9 @@
 #include <stdint.h>
 
 #define LOGOSDB_VERSION_MAJOR 0
-#define LOGOSDB_VERSION_MINOR 1
+#define LOGOSDB_VERSION_MINOR 2
 #define LOGOSDB_VERSION_PATCH 0
-#define LOGOSDB_VERSION_STRING "0.1.0"
+#define LOGOSDB_VERSION_STRING "0.2.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "logosdb"
-version = "0.1.0"
+version = "0.2.0"
 description = "Fast semantic vector database (HNSW + mmap) with Python bindings"
 readme = "README.md"
 license = { file = "LICENSE" }
-authors = [{ name = "Jose", email = "jose@example.com" }]
+authors = [{ name = "Jose", email = "jose-compu@users.noreply.github.com" }]
 requires-python = ">=3.9"
 keywords = ["vector-database", "hnsw", "embeddings", "semantic-search", "nearest-neighbor"]
 classifiers = [
@@ -49,3 +49,30 @@ LOGOSDB_BUILD_TESTS = "OFF"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]
+
+# ─────────────────────────────────────────────────────────────────────
+# cibuildwheel: produces binary wheels for every target platform.
+# Invoked by .github/workflows/publish.yml when a v* tag is pushed.
+# ─────────────────────────────────────────────────────────────────────
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+# Skip PyPy, 32-bit Linux, musl i686, and Windows (no Windows support yet,
+# see issue #10). Free-threaded CPython (cp3??t-*) is also skipped for now.
+skip = [
+    "pp*",
+    "*-musllinux_i686",
+    "*-manylinux_i686",
+    "*-win32",
+    "cp3??t-*",
+]
+build-verbosity = 1
+test-requires = "pytest"
+test-command = "pytest {project}/tests/python -v"
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+# Pin a stable macOS deployment target so wheels run on older hosts.
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }


### PR DESCRIPTION
Bumps project and Python package version to 0.2.0 and folds the three issues closed in this cycle into a single release:

  - #3  Public delete / update / count_live API, tombstone persistence and replay on index rebuild.
  - #1  GitHub Actions CI: matrix build on Linux and macOS (Debug + Release), ctest, CLI smoke test, build cache, concurrency.
  - #4  Python bindings (pybind11 + scikit-build-core) with numpy zero-copy views; pyproject.toml packaging; cibuildwheel config for CPython 3.9-3.13 on {linux,macos} x {x86_64,arm64}.

Also adds the PyPI release workflow (.github/workflows/publish.yml) with TestPyPI -> PyPI Trusted Publishing on v* tags, and a RELEASING.md runbook. Version bumped in logosdb.h, CMakeLists.txt, pyproject.toml, and README.md; CHANGELOG reorganized under the 0.2.0 heading.