### PR TITLE
Release v0.2.1: JSON parser fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 logosdb change log
 ==================
 
-unreleased
-----------
+0.2.1  (2026-04-20)
+-------------------
 
   * Replaced hand-rolled JSON parser with nlohmann/json (v3.11.3, single-header,
     vendored in third_party/nlohmann/). This fixes multiple parsing edge cases:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(logosdb VERSION 0.2.0 LANGUAGES CXX)
+project(logosdb VERSION 0.2.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Here is a performance report from the included `logosdb-bench` program. The resu
 
 We use databases with 1K, 10K, and 100K vectors. Each vector has 2048 dimensions (matching typical LLM embedding sizes). Vectors are L2-normalized random unit vectors.
 
-    LogosDB:    version 0.2.0
+    LogosDB:    version 0.2.1
     CPU:        Apple M-series (ARM64)
     Dim:        2048
     HNSW M:     16, ef_construction: 200, ef_search: 50

--- a/include/logosdb/logosdb.h
+++ b/include/logosdb/logosdb.h
@@ -6,8 +6,8 @@
 
 #define LOGOSDB_VERSION_MAJOR 0
 #define LOGOSDB_VERSION_MINOR 2
-#define LOGOSDB_VERSION_PATCH 0
-#define LOGOSDB_VERSION_STRING "0.2.0"
+#define LOGOSDB_VERSION_PATCH 1
+#define LOGOSDB_VERSION_STRING "0.2.1"
 
 #ifdef __cplusplus
 extern "C" {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "logosdb"
-version = "0.2.0"
+version = "0.2.1"
 description = "Fast semantic vector database (HNSW + mmap) with Python bindings"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Replace hand-rolled JSON parser with nlohmann/json v3.11.3. Fixes unicode escapes, key ordering sensitivity, whitespace handling. All 130 tests pass. Closes #5.