### PR TITLE
Add Mistral AI embeddings integration (#54)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,15 @@ logosdb change log
   * New ADR document: `docs/adr-002-training-free-quantization.md` describing
     the architecture decision and trade-offs.
 
+  Mistral AI embeddings integration (closes #54)
+
+  * New `python/logosdb/mistral.py` module with `MistralVectorStore`.
+  * Uses Mistral embeddings API (`mistral-embed`) with LogosDB backend storage.
+  * API: `add_texts()` and `search()` with batched embedding requests.
+  * Optional helper: `MistralEmbeddingProvider` for standalone embedding use.
+  * New optional extra: `pip install 'logosdb[mistral]'`.
+  * Added Python tests in `tests/python/test_mistral.py` (network-free via mock).
+
   Node.js bindings and npm package (closes #44)
 
   * New `nodejs/` directory with complete Node.js native addon:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ examples = ["sentence-transformers>=2.2"]
 langchain = ["langchain-core>=0.2", "numpy>=1.21"]
 llama-index = ["llama-index-core>=0.12", "numpy>=1.21"]
 haystack = ["haystack-ai>=2.0", "numpy>=1.21"]
+mistral = ["requests>=2.31", "numpy>=1.21"]
 
 [project.urls]
 Homepage = "https://github.com/jose-compu/logosdb"

--- a/python/logosdb/__init__.py
+++ b/python/logosdb/__init__.py
@@ -50,3 +50,13 @@ if LLAMAINDEX_AVAILABLE:
     __all__.append("LogosDBIndex")
 if HAYSTACK_AVAILABLE:
     __all__.extend(["LogosDBDocumentStore", "LogosDBRetriever"])
+
+# Mistral integration is available as optional import
+try:
+    from .mistral import MistralVectorStore, MistralEmbeddingProvider
+    MISTRAL_AVAILABLE = True
+except ImportError:
+    MISTRAL_AVAILABLE = False
+
+if MISTRAL_AVAILABLE:
+    __all__.extend(["MistralVectorStore", "MistralEmbeddingProvider"])

--- a/python/logosdb/mistral.py
+++ b/python/logosdb/mistral.py
@@ -1,0 +1,148 @@
+"""Mistral AI embeddings integration for LogosDB.
+
+This module provides a lightweight vector-store wrapper that uses
+Mistral embeddings and persists vectors in LogosDB.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+from ._core import DB, DIST_COSINE
+
+
+class MistralVectorStore:
+    """Mistral embeddings + LogosDB vector store.
+
+    Example:
+        >>> store = MistralVectorStore("/tmp/db", api_key="...", model="mistral-embed")
+        >>> store.add_texts(["doc one", "doc two"])
+        >>> store.search("doc", top_k=2)
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        api_key: Optional[str] = None,
+        model: str = "mistral-embed",
+        dim: int = 1024,
+        distance: int = DIST_COSINE,
+        max_elements: int = 1_000_000,
+        ef_construction: int = 200,
+        M: int = 16,
+        ef_search: int = 50,
+    ) -> None:
+        self._api_key = api_key or os.getenv("MISTRAL_API_KEY")
+        if not self._api_key:
+            raise ValueError("Mistral API key required (api_key or MISTRAL_API_KEY)")
+
+        self._model = model
+        self._dim = dim
+        self._db = DB(
+            path=uri,
+            dim=dim,
+            max_elements=max_elements,
+            ef_construction=ef_construction,
+            M=M,
+            ef_search=ef_search,
+            distance=distance,
+        )
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _request_embeddings(self, texts: Sequence[str]) -> List[List[float]]:
+        """Call Mistral embeddings endpoint and return vectors."""
+        import requests
+
+        resp = requests.post(
+            "https://api.mistral.ai/v1/embeddings",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            json={"model": self._model, "input": list(texts)},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        data = payload.get("data", [])
+        return [row["embedding"] for row in data]
+
+    def add_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> List[int]:
+        """Embed and insert texts. Returns inserted row IDs."""
+        if not texts:
+            return []
+
+        embeddings = self._request_embeddings(texts)
+        if len(embeddings) != len(texts):
+            raise RuntimeError("mistral embeddings count mismatch")
+
+        ids: List[int] = []
+        for i, (text, emb) in enumerate(zip(texts, embeddings)):
+            vec = np.asarray(emb, dtype=np.float32)
+            if vec.ndim != 1 or vec.shape[0] != self._dim:
+                raise ValueError(f"expected embedding dim={self._dim}, got {vec.shape}")
+
+            ts = ""
+            if metadatas and i < len(metadatas):
+                ts = str(metadatas[i].get("timestamp", "")) if metadatas[i] else ""
+            rid = self._db.put(vec, text=text, timestamp=ts)
+            ids.append(int(rid))
+        return ids
+
+    def search(self, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        """Search by query text."""
+        if top_k <= 0:
+            return []
+        q = self._request_embeddings([query])[0]
+        qvec = np.asarray(q, dtype=np.float32)
+        if qvec.shape[0] != self._dim:
+            raise ValueError(f"expected query dim={self._dim}, got {qvec.shape}")
+
+        hits = self._db.search(qvec, top_k=top_k)
+        return [
+            {"id": h.id, "text": h.text, "score": h.score, "timestamp": h.timestamp}
+            for h in hits
+        ]
+
+    def count(self) -> int:
+        return int(self._db.count())
+
+
+class MistralEmbeddingProvider:
+    """Standalone embedding provider wrapper for Mistral."""
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "mistral-embed") -> None:
+        self._api_key = api_key or os.getenv("MISTRAL_API_KEY")
+        if not self._api_key:
+            raise ValueError("Mistral API key required (api_key or MISTRAL_API_KEY)")
+        self._model = model
+
+    def embed(self, texts: Sequence[str]) -> List[List[float]]:
+        import requests
+
+        resp = requests.post(
+            "https://api.mistral.ai/v1/embeddings",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            json={"model": self._model, "input": list(texts)},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        return [row["embedding"] for row in payload.get("data", [])]

--- a/tests/python/test_mistral.py
+++ b/tests/python/test_mistral.py
@@ -1,0 +1,42 @@
+"""Tests for Mistral integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from logosdb.mistral import MistralVectorStore
+
+
+def _fake_embedding(text: str, dim: int) -> List[float]:
+    # Deterministic one-hot-ish vector by text hash
+    idx = abs(hash(text)) % dim
+    vec = [0.0] * dim
+    vec[idx] = 1.0
+    return vec
+
+
+def test_mistral_store_and_search(tmp_path: Path):
+    store = MistralVectorStore(str(tmp_path / "mistral_db"), api_key="test-key", dim=64)
+
+    # Mock API call to avoid network in tests
+    store._request_embeddings = lambda texts: [_fake_embedding(t, 64) for t in texts]  # type: ignore[attr-defined]
+
+    ids = store.add_texts(
+        ["apple", "banana", "carrot"],
+        metadatas=[{"timestamp": "2026-01-01T00:00:00Z"}, {}, {}],
+    )
+    assert ids == [0, 1, 2]
+    assert store.count() == 3
+
+    hits = store.search("banana", top_k=3)
+    assert len(hits) >= 1
+    assert hits[0]["text"] == "banana"
+
+
+def test_mistral_missing_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="Mistral API key required"):
+        MistralVectorStore(str(tmp_path / "mistral_db"))


### PR DESCRIPTION
- New MistralVectorStore in python/logosdb/mistral.py
- Add MistralEmbeddingProvider helper
- Export Mistral integration from package __init__
- Add optional dependency extra: logosdb[mistral]
- Add tests for store/search and missing API key
- Update changelog for issue #54

Closes #54
Milestone: 0.7.0