### PR TITLE
feat(vibe): add Mistral Vibe memory integration (issue #63)

### DIFF
--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -1,0 +1,45 @@
+# .vibe/config.toml — LogosDB integration for Mistral Vibe
+#
+# Option A (recommended): MCP server — reuses the same logosdb-mcp-server
+# as Claude Code. All 6 tools (logosdb_index, logosdb_index_file,
+# logosdb_search, logosdb_list, logosdb_info, logosdb_delete) are exposed.
+#
+# Option B: Use the Python VibeMemory class directly via bash tool or a
+# custom skill (see .vibe/skills/logosdb-memory/SKILL.md).
+
+# ── MCP server (Option A) ────────────────────────────────────────────────────
+
+[[mcp_servers]]
+name       = "logosdb"
+transport  = "stdio"
+command    = "npx"
+args       = ["-y", "logosdb-mcp-server"]
+env        = { LOGOSDB_PATH = "./.logosdb", EMBEDDING_PROVIDER = "voyage", VOYAGE_API_KEY = "" }
+
+# Replace VOYAGE_API_KEY with your key, or switch to OpenAI:
+#   env = { LOGOSDB_PATH = "./.logosdb", EMBEDDING_PROVIDER = "openai", OPENAI_API_KEY = "" }
+
+# ── Tool permissions ─────────────────────────────────────────────────────────
+
+[tools.logosdb_search]
+permission = "always"
+
+[tools.logosdb_list]
+permission = "always"
+
+[tools.logosdb_info]
+permission = "always"
+
+[tools.logosdb_index]
+permission = "ask"
+
+[tools.logosdb_index_file]
+permission = "ask"
+
+[tools.logosdb_delete]
+permission = "ask"
+
+# ── Skills ───────────────────────────────────────────────────────────────────
+
+# Enables the logosdb-memory slash command and Python API documentation.
+enabled_skills = ["logosdb-memory"]

--- a/.vibe/skills/logosdb-memory/SKILL.md
+++ b/.vibe/skills/logosdb-memory/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: logosdb-memory
+description: Semantic memory for Mistral Vibe — index code/docs, search across sessions, forget outdated knowledge using LogosDB + Mistral embeddings.
+license: MIT
+compatibility: Python 3.9+
+user-invocable: true
+allowed-tools:
+  - bash
+  - read_file
+  - grep
+---
+
+# LogosDB Memory Skill
+
+Gives Vibe persistent semantic memory across sessions by indexing your project
+into a local LogosDB vector store and performing sub-millisecond semantic search.
+
+## Prerequisites
+
+```bash
+pip install 'logosdb[mistral]'   # or: pip install logosdb requests numpy
+export MISTRAL_API_KEY="..."
+```
+
+## Setup
+
+Add `LOGOSDB_PATH` to your environment (or `.vibe/.env`) to set where databases
+are stored (default: `./.logosdb`):
+
+```bash
+LOGOSDB_PATH=./.logosdb
+MISTRAL_API_KEY=your_key_here
+```
+
+## Slash command usage (inside Vibe)
+
+```
+/logosdb-memory index ./src --namespace code
+/logosdb-memory search "where is JWT validated" --namespace code --top-k 5
+/logosdb-memory forget --namespace code --query "old feature"
+/logosdb-memory info
+/logosdb-memory list
+```
+
+## Standalone CLI
+
+```bash
+logosdb-vibe index ./src --namespace code
+logosdb-vibe search "retry logic" --namespace code --top-k 5
+logosdb-vibe forget --namespace code --id 42
+logosdb-vibe info --namespace code
+logosdb-vibe list
+```
+
+## Python API (inside a Vibe tool or script)
+
+```python
+from logosdb.vibe import VibeMemory
+
+mem = VibeMemory(uri="./.logosdb")        # reads MISTRAL_API_KEY from env
+
+# Index an entire directory
+mem.index("./src", namespace="code")
+
+# Search
+results = mem.search("where is JWT validated?", namespace="code", top_k=5)
+for r in results:
+    print(r["score"], r["file"], r["text"][:120])
+
+# Forget by semantic match
+mem.forget(namespace="code", query="deprecated auth module")
+
+# Forget by ID (from search result)
+mem.forget(namespace="code", memory_id=42)
+
+# Stats
+print(mem.info())
+```
+
+## Namespaces
+
+Use separate namespaces to keep concerns isolated:
+
+| Namespace | Content |
+|---|---|
+| `code`  | Source files (`./src`, `./lib`) |
+| `docs`  | Markdown, RST (`./docs`) |
+| `tests` | Test files (`./tests`) |
+| `notes` | Free-form session notes |
+
+## MCP alternative
+
+Vibe also supports MCP servers. To use the same LogosDB server as Claude Code,
+see `.vibe/config.toml` in this project for the `[[mcp_servers]]` configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ anthropic = ["requests>=2.31", "numpy>=1.21"]
 huggingface = ["sentence-transformers>=2.2", "numpy>=1.21"]
 cohere = ["requests>=2.31", "numpy>=1.21"]
 mem0 = ["mem0ai>=0.1", "numpy>=1.21"]
+vibe = ["requests>=2.31", "numpy>=1.21"]
+
+[project.scripts]
+logosdb-vibe = "logosdb._vibe_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/jose-compu/logosdb"

--- a/python/logosdb/__init__.py
+++ b/python/logosdb/__init__.py
@@ -110,3 +110,13 @@ except ImportError:
 
 if MEM0_AVAILABLE:
     __all__.append("Mem0VectorStore")
+
+# Mistral Vibe memory adapter is available as optional import
+try:
+    from .vibe import VibeMemory
+    VIBE_AVAILABLE = True
+except ImportError:
+    VIBE_AVAILABLE = False
+
+if VIBE_AVAILABLE:
+    __all__.append("VibeMemory")

--- a/python/logosdb/_vibe_cli.py
+++ b/python/logosdb/_vibe_cli.py
@@ -1,0 +1,102 @@
+"""CLI entry point for ``logosdb-vibe``.
+
+Usage::
+
+    logosdb-vibe index ./src --namespace code
+    logosdb-vibe search "retry logic" --namespace code --top-k 5
+    logosdb-vibe forget --namespace code --query "old feature"
+    logosdb-vibe forget --namespace code --id 42
+    logosdb-vibe info [--namespace code]
+    logosdb-vibe list
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+
+def _mem() -> "VibeMemory":  # noqa: F821 — imported lazily to keep startup fast
+    from .vibe import VibeMemory
+
+    return VibeMemory(
+        uri=os.getenv("LOGOSDB_PATH", "./.logosdb"),
+        api_key=os.getenv("MISTRAL_API_KEY"),
+    )
+
+
+def _print(data: object) -> None:
+    print(json.dumps(data, indent=2, default=str))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="logosdb-vibe",
+        description="LogosDB memory layer for Mistral Vibe",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    # index
+    p_idx = sub.add_parser("index", help="Index a file or directory")
+    p_idx.add_argument("path", help="File or directory to index")
+    p_idx.add_argument("--namespace", "-n", default="code")
+    p_idx.add_argument("--chunk-size", type=int, default=800)
+
+    # search
+    p_srch = sub.add_parser("search", help="Semantic search")
+    p_srch.add_argument("query")
+    p_srch.add_argument("--namespace", "-n", default="code")
+    p_srch.add_argument("--top-k", "-k", type=int, default=5)
+
+    # forget
+    p_fgt = sub.add_parser("forget", help="Delete entries by ID or query")
+    p_fgt.add_argument("--namespace", "-n", default="code")
+    grp = p_fgt.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--id", type=int, dest="memory_id", metavar="ID")
+    grp.add_argument("--query", "-q")
+    p_fgt.add_argument("--top-k", "-k", type=int, default=1)
+
+    # info
+    p_inf = sub.add_parser("info", help="Database statistics")
+    p_inf.add_argument("--namespace", "-n", default=None)
+
+    # list
+    sub.add_parser("list", help="List all namespaces")
+
+    args = parser.parse_args(argv)
+
+    try:
+        mem = _mem()
+
+        if args.cmd == "index":
+            _print(mem.index(args.path, namespace=args.namespace, chunk_size=args.chunk_size))
+
+        elif args.cmd == "search":
+            results = mem.search(args.query, namespace=args.namespace, top_k=args.top_k)
+            _print(results)
+
+        elif args.cmd == "forget":
+            _print(
+                mem.forget(
+                    namespace=args.namespace,
+                    memory_id=args.memory_id,
+                    query=args.query,
+                    top_k=args.top_k,
+                )
+            )
+
+        elif args.cmd == "info":
+            _print(mem.info(namespace=args.namespace))
+
+        elif args.cmd == "list":
+            _print(mem.list_namespaces())
+
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/logosdb/vibe.py
+++ b/python/logosdb/vibe.py
@@ -1,0 +1,328 @@
+"""Mistral Vibe memory adapter for LogosDB.
+
+Wraps :class:`logosdb.mistral.MistralVectorStore` with a chunking pipeline and
+namespace management so that Mistral Vibe can index, search, and forget
+project knowledge across sessions.
+
+Quick start inside a Vibe session::
+
+    from logosdb.vibe import VibeMemory
+
+    mem = VibeMemory(uri="./.logosdb")       # reads MISTRAL_API_KEY from env
+
+    # index a file or entire directory
+    mem.index("./src", namespace="code")
+
+    # semantic search
+    results = mem.search("where is JWT validated?", namespace="code", top_k=5)
+
+    # forget by ID or by closest semantic match
+    mem.forget(namespace="code", memory_id=3)
+    mem.forget(namespace="code", query="JWT validation code")
+
+    # database statistics
+    print(mem.info())
+
+CLI entry point (``logosdb-vibe``)::
+
+    logosdb-vibe index ./src --namespace code
+    logosdb-vibe search "retry logic" --namespace code --top-k 5
+    logosdb-vibe forget --namespace code --query "old feature"
+    logosdb-vibe info
+    logosdb-vibe list
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from .mistral import MistralVectorStore
+
+
+# ---------------------------------------------------------------------------
+# File extensions considered indexable text
+# ---------------------------------------------------------------------------
+
+_DEFAULT_EXTENSIONS = {
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java", ".c", ".cpp",
+    ".h", ".hpp", ".cs", ".rb", ".php", ".swift", ".kt", ".scala", ".sh",
+    ".bash", ".zsh", ".fish", ".md", ".rst", ".txt", ".toml", ".yaml", ".yml",
+    ".json", ".env.example", ".cfg", ".ini", ".sql",
+}
+
+
+# ---------------------------------------------------------------------------
+# Paragraph-aware chunker (mirrors mcp/src/chunker.ts)
+# ---------------------------------------------------------------------------
+
+def _chunk_text(text: str, target_chars: int = 800, overlap_chars: int = 100) -> List[str]:
+    """Split *text* into overlapping paragraph-aware chunks."""
+    paragraphs = re.split(r"\n{2,}", text)
+    chunks: List[str] = []
+    buffer = ""
+
+    for para in paragraphs:
+        trimmed = para.strip()
+        if not trimmed:
+            continue
+        if buffer and len(buffer) + len(trimmed) + 1 > target_chars:
+            chunks.append(buffer.strip())
+            overlap = buffer[-overlap_chars:] if len(buffer) > overlap_chars else buffer
+            buffer = overlap + "\n" + trimmed
+        else:
+            buffer = (buffer + "\n\n" + trimmed) if buffer else trimmed
+
+    if buffer.strip():
+        chunks.append(buffer.strip())
+
+    return chunks if chunks else [text.strip()]
+
+
+# ---------------------------------------------------------------------------
+# VibeMemory
+# ---------------------------------------------------------------------------
+
+class VibeMemory:
+    """Mistral Vibe memory layer backed by LogosDB.
+
+    Each namespace maps to a separate :class:`~logosdb.mistral.MistralVectorStore`
+    stored under *uri/<namespace>/*.
+
+    Args:
+        uri:            Root directory for all namespace databases.
+        api_key:        Mistral API key (falls back to ``MISTRAL_API_KEY`` env var).
+        model:          Mistral embedding model (default ``"mistral-embed"``).
+        chunk_size:     Target characters per chunk when indexing files.
+        overlap_chars:  Overlap between consecutive chunks.
+        dim:            Embedding dimension (1024 for mistral-embed).
+    """
+
+    def __init__(
+        self,
+        uri: str = "./.logosdb",
+        api_key: Optional[str] = None,
+        model: str = "mistral-embed",
+        chunk_size: int = 800,
+        overlap_chars: int = 100,
+        dim: int = 1024,
+    ) -> None:
+        self._root = Path(uri)
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._api_key = api_key or os.getenv("MISTRAL_API_KEY", "")
+        if not self._api_key:
+            raise ValueError(
+                "Mistral API key required. Set MISTRAL_API_KEY or pass api_key=."
+            )
+        self._model = model
+        self._chunk_size = chunk_size
+        self._overlap_chars = overlap_chars
+        self._dim = dim
+        self._stores: Dict[str, MistralVectorStore] = {}
+
+    # ── Internal helpers ─────────────────────────────────────────────────────
+
+    def _store(self, namespace: str) -> MistralVectorStore:
+        if namespace not in self._stores:
+            ns_path = str(self._root / namespace)
+            self._stores[namespace] = MistralVectorStore(
+                uri=ns_path,
+                api_key=self._api_key,
+                model=self._model,
+                dim=self._dim,
+            )
+        return self._stores[namespace]
+
+    @staticmethod
+    def _validate_namespace(namespace: str) -> None:
+        if not re.fullmatch(r"[a-zA-Z0-9_\-\.]+", namespace):
+            raise ValueError(
+                f'Invalid namespace "{namespace}". Use [a-z A-Z 0-9 _ - .] only.'
+            )
+
+    # ── Public API ───────────────────────────────────────────────────────────
+
+    def index(
+        self,
+        path: str,
+        namespace: str = "code",
+        chunk_size: Optional[int] = None,
+        extensions: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        """Index a file or directory into *namespace*.
+
+        Reads each matching file, splits it into overlapping chunks, embeds
+        them with Mistral, and stores them in LogosDB.
+
+        Args:
+            path:       File or directory to index.
+            namespace:  Collection name (e.g. ``"code"``, ``"docs"``).
+            chunk_size: Override default chunk size (chars).
+            extensions: Set of file extensions to include (e.g. ``{".py", ".md"}``).
+
+        Returns:
+            ``{"indexed": N, "files": M, "namespace": namespace, "path": path}``
+        """
+        self._validate_namespace(namespace)
+        store = self._store(namespace)
+        target = Path(path).expanduser()
+        cs = chunk_size or self._chunk_size
+        exts = set(extensions) if extensions else _DEFAULT_EXTENSIONS
+        ts = datetime.now(timezone.utc).isoformat()
+
+        files: List[Path] = []
+        if target.is_file():
+            files = [target]
+        elif target.is_dir():
+            files = [
+                p for p in target.rglob("*")
+                if p.is_file() and p.suffix in exts
+            ]
+        else:
+            raise FileNotFoundError(f"Path not found: {target}")
+
+        total_chunks = 0
+        for file_path in files:
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+
+            chunks = _chunk_text(content, target_chars=cs, overlap_chars=self._overlap_chars)
+            texts = [
+                f"[file:{file_path}][chunk:{i}/{len(chunks)}]\n{c}"
+                for i, c in enumerate(chunks)
+            ]
+            metadatas = [{"timestamp": ts} for _ in texts]
+            store.add_texts(texts, metadatas=metadatas)
+            total_chunks += len(chunks)
+
+        return {
+            "indexed": total_chunks,
+            "files": len(files),
+            "namespace": namespace,
+            "path": str(target),
+        }
+
+    def search(
+        self,
+        query: str,
+        namespace: str = "code",
+        top_k: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Semantic search over *namespace*.
+
+        Args:
+            query:     Natural-language query.
+            namespace: Collection to search in.
+            top_k:     Number of results.
+
+        Returns:
+            List of ``{"id", "text", "score", "timestamp", "file"}`` dicts,
+            sorted by descending score.
+        """
+        self._validate_namespace(namespace)
+        ns_path = self._root / namespace
+        if not ns_path.exists():
+            return []
+
+        store = self._store(namespace)
+        hits = store.search(query, top_k=top_k)
+
+        results = []
+        for h in hits:
+            text = h.get("text") or ""
+            # Extract file path from [file:...] prefix if present
+            file_match = re.match(r"\[file:([^\]]+)\]", text)
+            file_path = file_match.group(1) if file_match else None
+            # Strip label prefix for display
+            display = re.sub(r"^\[file:[^\]]+\]\[chunk:\d+/\d+\]\n?", "", text)
+            results.append(
+                {
+                    "id": h["id"],
+                    "score": round(h["score"], 4),
+                    "text": display,
+                    "timestamp": h.get("timestamp"),
+                    "file": file_path,
+                }
+            )
+        return results
+
+    def forget(
+        self,
+        namespace: str = "code",
+        memory_id: Optional[int] = None,
+        query: Optional[str] = None,
+        top_k: int = 1,
+    ) -> Dict[str, Any]:
+        """Delete one or more entries from *namespace*.
+
+        Exactly one of *memory_id* or *query* must be provided.
+
+        - ``memory_id``: delete the entry with that row ID.
+        - ``query``: find the *top_k* closest matches and delete them.
+
+        Returns:
+            ``{"forgotten": N, "namespace": namespace}``
+        """
+        self._validate_namespace(namespace)
+        if memory_id is None and query is None:
+            raise ValueError("Provide either memory_id or query.")
+        if memory_id is not None and query is not None:
+            raise ValueError("Provide only one of memory_id or query, not both.")
+
+        store = self._store(namespace)
+
+        if memory_id is not None:
+            store._db.delete(memory_id)
+            return {"forgotten": 1, "namespace": namespace, "ids": [memory_id]}
+
+        # Query-based: embed query, find closest matches, delete
+        hits = self.search(query or "", namespace=namespace, top_k=top_k)
+        ids = [h["id"] for h in hits]
+        for row_id in ids:
+            store._db.delete(row_id)
+        return {"forgotten": len(ids), "namespace": namespace, "ids": ids}
+
+    def info(self, namespace: Optional[str] = None) -> Dict[str, Any]:
+        """Return statistics for one or all namespaces.
+
+        Args:
+            namespace: If given, stats for that namespace only.
+                       If ``None``, stats for every existing namespace.
+
+        Returns:
+            Dict (single namespace) or list of dicts (all namespaces).
+        """
+        if namespace is not None:
+            self._validate_namespace(namespace)
+            ns_path = self._root / namespace
+            if not ns_path.exists():
+                raise FileNotFoundError(f'Namespace "{namespace}" does not exist.')
+            store = self._store(namespace)
+            return {
+                "namespace": namespace,
+                "count": store.count(),
+                "path": str(ns_path),
+                "model": self._model,
+                "dim": self._dim,
+            }
+
+        namespaces = self.list_namespaces()
+        return {  # type: ignore[return-value]
+            "namespaces": [self.info(ns) for ns in namespaces],
+            "root": str(self._root),
+        }
+
+    def list_namespaces(self) -> List[str]:
+        """Return names of all indexed namespaces under the root directory."""
+        try:
+            return [
+                d.name for d in self._root.iterdir()
+                if d.is_dir()
+            ]
+        except FileNotFoundError:
+            return []

--- a/tests/python/test_vibe.py
+++ b/tests/python/test_vibe.py
@@ -12,10 +12,9 @@ from __future__ import annotations
 
 import json
 import re
-import tempfile
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -27,6 +26,10 @@ import pytest
 
 _DIM = 8  # small dimension to keep tests fast
 
+# Target to patch: _request_embeddings lives on MistralVectorStore.
+# Patching here avoids importing `requests` entirely.
+_EMBED_TARGET = "logosdb.mistral.MistralVectorStore._request_embeddings"
+
 
 def _fake_embedding(text: str, dim: int = _DIM) -> list[float]:
     """Deterministic fake embedding based on text hash."""
@@ -36,39 +39,9 @@ def _fake_embedding(text: str, dim: int = _DIM) -> list[float]:
     return v.tolist()
 
 
-def _mock_mistral_post(url: str, **kwargs: Any) -> MagicMock:
-    """Fake requests.post that intercepts the Mistral embeddings call."""
-    body = kwargs.get("json", {})
-    inputs = body.get("input", [])
-    embeddings = [{"embedding": _fake_embedding(t, _DIM)} for t in inputs]
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"data": embeddings}
-    resp.raise_for_status = lambda: None
-    return resp
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-@pytest.fixture()
-def mem(tmp_path: Path):
-    """VibeMemory instance with a temp root and mocked Mistral calls."""
-    with patch("requests.post", side_effect=_mock_mistral_post):
-        from logosdb.vibe import VibeMemory
-
-        # Patch _DIM into the store so LogosDB uses dim=8
-        with patch("logosdb.mistral.MistralVectorStore.__init__", wraps=_patched_init):
-            yield VibeMemory(uri=str(tmp_path / "logosdb"), api_key="fake-key", dim=_DIM)
-
-
-def _patched_init(self: Any, uri: str, **kwargs: Any) -> None:
-    """Wrap MistralVectorStore.__init__ to force dim=_DIM."""
-    from logosdb.mistral import MistralVectorStore
-
-    kwargs["dim"] = _DIM
-    MistralVectorStore.__init__.__wrapped__(self, uri=uri, **kwargs)  # type: ignore[attr-defined]
+def _mock_request_embeddings(self: Any, texts: Any) -> list[list[float]]:
+    """Replaces MistralVectorStore._request_embeddings — no HTTP, no requests."""
+    return [_fake_embedding(str(t), _DIM) for t in texts]
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +105,7 @@ class TestVibeMemory:
         src = tmp_path / "hello.py"
         src.write_text("def hello():\n    return 'world'\n")
 
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -149,7 +122,7 @@ class TestVibeMemory:
         (src / "b.py").write_text("def b(): pass")
         (src / "ignore.bin").write_bytes(b"\x00\x01")
 
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -161,7 +134,7 @@ class TestVibeMemory:
         src = tmp_path / "auth.py"
         src.write_text("def validate_jwt(token):\n    # JWT validation logic\n    pass\n")
 
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -176,7 +149,7 @@ class TestVibeMemory:
             assert "text" in r
 
     def test_search_empty_namespace_returns_empty(self, tmp_path: Path) -> None:
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -188,7 +161,7 @@ class TestVibeMemory:
         src = tmp_path / "x.py"
         src.write_text("x = 1\n")
 
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -205,7 +178,7 @@ class TestVibeMemory:
         src = tmp_path / "y.py"
         src.write_text("y = 2\n")
 
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -214,7 +187,7 @@ class TestVibeMemory:
             assert outcome["forgotten"] >= 1
 
     def test_forget_requires_id_or_query(self, tmp_path: Path) -> None:
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -225,7 +198,7 @@ class TestVibeMemory:
         src = tmp_path / "z.py"
         src.write_text("z = 3\n")
 
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -239,7 +212,7 @@ class TestVibeMemory:
         src = tmp_path / "f.py"
         src.write_text("pass\n")
 
-        with patch("requests.post", side_effect=_mock_mistral_post):
+        with patch(_EMBED_TARGET, _mock_request_embeddings):
             from logosdb.vibe import VibeMemory
 
             mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
@@ -266,7 +239,7 @@ class TestVibeCli:
         src = tmp_path / "cli_test.py"
         src.write_text("def cli_function(): pass\n")
 
-        with patch("requests.post", side_effect=_mock_mistral_post), \
+        with patch(_EMBED_TARGET, _mock_request_embeddings), \
              patch.dict("os.environ", {
                  "LOGOSDB_PATH": str(tmp_path / "db"),
                  "MISTRAL_API_KEY": "fake",

--- a/tests/python/test_vibe.py
+++ b/tests/python/test_vibe.py
@@ -1,0 +1,296 @@
+"""Smoke tests for logosdb.vibe.VibeMemory.
+
+These tests mock Mistral API calls so no real API key or network is needed.
+They exercise the full index → search → forget pipeline and all helper methods.
+
+Run with::
+
+    pytest tests/python/test_vibe.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DIM = 8  # small dimension to keep tests fast
+
+
+def _fake_embedding(text: str, dim: int = _DIM) -> list[float]:
+    """Deterministic fake embedding based on text hash."""
+    rng = np.random.default_rng(abs(hash(text)) % (2**32))
+    v = rng.standard_normal(dim).astype(np.float32)
+    v /= np.linalg.norm(v)
+    return v.tolist()
+
+
+def _mock_mistral_post(url: str, **kwargs: Any) -> MagicMock:
+    """Fake requests.post that intercepts the Mistral embeddings call."""
+    body = kwargs.get("json", {})
+    inputs = body.get("input", [])
+    embeddings = [{"embedding": _fake_embedding(t, _DIM)} for t in inputs]
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"data": embeddings}
+    resp.raise_for_status = lambda: None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mem(tmp_path: Path):
+    """VibeMemory instance with a temp root and mocked Mistral calls."""
+    with patch("requests.post", side_effect=_mock_mistral_post):
+        from logosdb.vibe import VibeMemory
+
+        # Patch _DIM into the store so LogosDB uses dim=8
+        with patch("logosdb.mistral.MistralVectorStore.__init__", wraps=_patched_init):
+            yield VibeMemory(uri=str(tmp_path / "logosdb"), api_key="fake-key", dim=_DIM)
+
+
+def _patched_init(self: Any, uri: str, **kwargs: Any) -> None:
+    """Wrap MistralVectorStore.__init__ to force dim=_DIM."""
+    from logosdb.mistral import MistralVectorStore
+
+    kwargs["dim"] = _DIM
+    MistralVectorStore.__init__.__wrapped__(self, uri=uri, **kwargs)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no DB, no network
+# ---------------------------------------------------------------------------
+
+class TestChunker:
+    def test_single_paragraph(self) -> None:
+        from logosdb.vibe import _chunk_text
+
+        chunks = _chunk_text("Hello world", target_chars=200)
+        assert len(chunks) == 1
+        assert chunks[0] == "Hello world"
+
+    def test_splits_on_blank_lines(self) -> None:
+        from logosdb.vibe import _chunk_text
+
+        text = "Para one.\n\nPara two.\n\nPara three."
+        chunks = _chunk_text(text, target_chars=20)
+        assert len(chunks) > 1
+
+    def test_overlap(self) -> None:
+        from logosdb.vibe import _chunk_text
+
+        long_text = "\n\n".join([f"Paragraph {i} with some content." for i in range(20)])
+        chunks = _chunk_text(long_text, target_chars=80, overlap_chars=20)
+        # Each chunk after the first should begin with part of the previous
+        assert all(len(c) > 0 for c in chunks)
+
+    def test_empty_string_returns_one_chunk(self) -> None:
+        from logosdb.vibe import _chunk_text
+
+        chunks = _chunk_text("", target_chars=100)
+        assert len(chunks) == 1
+
+
+class TestNamespaceValidation:
+    def test_valid_namespace(self) -> None:
+        from logosdb.vibe import VibeMemory
+
+        VibeMemory._validate_namespace("code")
+        VibeMemory._validate_namespace("my-namespace")
+        VibeMemory._validate_namespace("ns_1.2")
+
+    def test_invalid_namespace_raises(self) -> None:
+        from logosdb.vibe import VibeMemory
+
+        with pytest.raises(ValueError, match="Invalid namespace"):
+            VibeMemory._validate_namespace("bad namespace")
+
+        with pytest.raises(ValueError, match="Invalid namespace"):
+            VibeMemory._validate_namespace("../../etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real LogosDB, mocked Mistral
+# ---------------------------------------------------------------------------
+
+class TestVibeMemory:
+    def test_index_file(self, tmp_path: Path) -> None:
+        src = tmp_path / "hello.py"
+        src.write_text("def hello():\n    return 'world'\n")
+
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            result = mem.index(str(src), namespace="code")
+
+        assert result["indexed"] >= 1
+        assert result["files"] == 1
+        assert result["namespace"] == "code"
+
+    def test_index_directory(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.py").write_text("def a(): pass")
+        (src / "b.py").write_text("def b(): pass")
+        (src / "ignore.bin").write_bytes(b"\x00\x01")
+
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            result = mem.index(str(src), namespace="code")
+
+        assert result["files"] == 2  # .bin skipped
+
+    def test_search_returns_results(self, tmp_path: Path) -> None:
+        src = tmp_path / "auth.py"
+        src.write_text("def validate_jwt(token):\n    # JWT validation logic\n    pass\n")
+
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            mem.index(str(src), namespace="code")
+            results = mem.search("JWT validation", namespace="code", top_k=3)
+
+        assert isinstance(results, list)
+        assert len(results) >= 1
+        for r in results:
+            assert "id" in r
+            assert "score" in r
+            assert "text" in r
+
+    def test_search_empty_namespace_returns_empty(self, tmp_path: Path) -> None:
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            results = mem.search("anything", namespace="nonexistent")
+
+        assert results == []
+
+    def test_forget_by_id(self, tmp_path: Path) -> None:
+        src = tmp_path / "x.py"
+        src.write_text("x = 1\n")
+
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            mem.index(str(src), namespace="code")
+            results_before = mem.search("x = 1", namespace="code", top_k=5)
+            assert results_before
+
+            row_id = results_before[0]["id"]
+            outcome = mem.forget(namespace="code", memory_id=row_id)
+            assert outcome["forgotten"] == 1
+            assert row_id in outcome["ids"]
+
+    def test_forget_by_query(self, tmp_path: Path) -> None:
+        src = tmp_path / "y.py"
+        src.write_text("y = 2\n")
+
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            mem.index(str(src), namespace="code")
+            outcome = mem.forget(namespace="code", query="y = 2", top_k=1)
+            assert outcome["forgotten"] >= 1
+
+    def test_forget_requires_id_or_query(self, tmp_path: Path) -> None:
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            with pytest.raises(ValueError):
+                mem.forget(namespace="code")
+
+    def test_info_single_namespace(self, tmp_path: Path) -> None:
+        src = tmp_path / "z.py"
+        src.write_text("z = 3\n")
+
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            mem.index(str(src), namespace="code")
+            info = mem.info(namespace="code")
+
+        assert info["namespace"] == "code"
+        assert info["count"] >= 1
+
+    def test_list_namespaces(self, tmp_path: Path) -> None:
+        src = tmp_path / "f.py"
+        src.write_text("pass\n")
+
+        with patch("requests.post", side_effect=_mock_mistral_post):
+            from logosdb.vibe import VibeMemory
+
+            mem = VibeMemory(uri=str(tmp_path / "db"), api_key="fake", dim=_DIM)
+            mem.index(str(src), namespace="code")
+            mem.index(str(src), namespace="tests")
+            namespaces = mem.list_namespaces()
+
+        assert set(namespaces) >= {"code", "tests"}
+
+    def test_missing_api_key_raises(self, tmp_path: Path) -> None:
+        from logosdb.vibe import VibeMemory
+
+        with pytest.raises(ValueError, match="Mistral API key"):
+            with patch.dict("os.environ", {}, clear=True):
+                VibeMemory(uri=str(tmp_path / "db"), api_key="")
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test
+# ---------------------------------------------------------------------------
+
+class TestVibeCli:
+    def test_cli_index_and_search(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        src = tmp_path / "cli_test.py"
+        src.write_text("def cli_function(): pass\n")
+
+        with patch("requests.post", side_effect=_mock_mistral_post), \
+             patch.dict("os.environ", {
+                 "LOGOSDB_PATH": str(tmp_path / "db"),
+                 "MISTRAL_API_KEY": "fake",
+             }):
+            # Monkey-patch dim inside VibeMemory for the CLI path
+            import logosdb._vibe_cli as cli_mod
+            orig_mem = cli_mod._mem
+
+            def _patched_mem():
+                from logosdb.vibe import VibeMemory
+                return VibeMemory(
+                    uri=str(tmp_path / "db"), api_key="fake", dim=_DIM
+                )
+
+            cli_mod._mem = _patched_mem  # type: ignore[assignment]
+            try:
+                from logosdb._vibe_cli import main
+
+                main(["index", str(src), "--namespace", "code"])
+                out = json.loads(capsys.readouterr().out)
+                assert out["files"] == 1
+
+                main(["list"])
+                out2 = json.loads(capsys.readouterr().out)
+                assert "code" in out2
+            finally:
+                cli_mod._mem = orig_mem


### PR DESCRIPTION
closes #63

This pull request introduces a new integration between LogosDB and Mistral Vibe, enabling persistent semantic memory for Vibe sessions. The main changes add a new `VibeMemory` Python class, a CLI tool (`logosdb-vibe`), configuration and documentation for Vibe integration, and support for managing and searching semantic memory across code, docs, and other project files. This allows users to index, search, and forget knowledge using both CLI and Python API, with support for namespaces and chunked semantic search.

**Mistral Vibe Integration and Memory Layer:**

* Added the `VibeMemory` class (`python/logosdb/vibe.py`) that wraps LogosDB's vector store for use in Mistral Vibe, supporting indexing, semantic search, forgetting entries, statistics, and namespace management. This includes a paragraph-aware chunking pipeline and file extension filtering.
* Updated the LogosDB Python package to optionally expose `VibeMemory` in its public API (`python/logosdb/__init__.py`).

**CLI and Tooling Support:**

* Introduced the `logosdb-vibe` CLI tool (`python/logosdb/_vibe_cli.py`), allowing users to index, search, forget, list, and get info about semantic memory from the command line, mirroring the Python API.
* Registered the CLI entry point in `pyproject.toml` and added required dependencies for the new `vibe` extra.

**Vibe Configuration and Documentation:**

* Added `.vibe/config.toml` to configure the LogosDB MCP server integration and tool permissions for Vibe, with instructions for both server and skill-based setups.
* Documented the `logosdb-memory` skill in `.vibe/skills/logosdb-memory/SKILL.md`, covering prerequisites, setup, usage examples (slash commands, CLI, Python API), and namespace organization.