### PR TITLE
feat(mcp): directory indexing + slash commands /index /search /forget

### DIFF
--- a/.claude/commands/forget.md
+++ b/.claude/commands/forget.md
@@ -1,0 +1,11 @@
+Delete an entry from LogosDB by row ID.
+
+Arguments: $ARGUMENTS
+
+Parse the arguments:
+- `--namespace=<name>` or `-n <name>` sets the collection (default: "code")
+- `--id=<number>` or positional number is the row ID to delete
+
+Call the `logosdb_delete` tool with the namespace and id.
+
+Respond: Deleted entry {id} from '{namespace}' namespace.

--- a/.claude/commands/index.md
+++ b/.claude/commands/index.md
@@ -1,0 +1,12 @@
+Index a file or directory into LogosDB for semantic search.
+
+Arguments: $ARGUMENTS
+
+Parse the arguments:
+- First positional argument is the path to index (file or directory)
+- `--namespace=<name>` or `-n <name>` sets the collection name (default: "code")
+
+Call the `logosdb_index_file` tool with the resolved path and namespace.
+
+When done, respond in exactly this format (no extra prose):
+Indexed {files} files into '{namespace}' collection

--- a/.claude/commands/search.md
+++ b/.claude/commands/search.md
@@ -1,0 +1,19 @@
+Search LogosDB for semantically similar content.
+
+Arguments: $ARGUMENTS
+
+Parse the arguments:
+- Everything before any flag is the search query
+- `--namespace=<name>` or `-n <name>` sets the collection (default: "code")
+- `--top-k=<n>` or `-k <n>` sets the number of results (default: 5)
+
+Call the `logosdb_search` tool with the query, namespace, and top_k.
+
+Present results in exactly this format:
+Searching... Found {N} matches:
+  1. {file_path} (score: {score})
+  2. {file_path} (score: {score})
+  ...
+
+Extract the file path from the [file:...] prefix in the result text.
+If no results, respond: No matches found in '{namespace}' namespace.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -40,6 +40,71 @@ For Voyage AI embeddings (Anthropic-recommended, dim=1024):
 }
 ```
 
+## Slash commands
+
+Three custom slash commands are included in `.claude/commands/` and are available as soon as you open Claude Code in this project:
+
+| Command | Example |
+|---|---|
+| `/index` | `/index ./src --namespace=backend` |
+| `/search` | `/search "JWT validation" --namespace=backend` |
+| `/forget` | `/forget --namespace=backend --id=42` |
+
+## Example session
+
+Once configured, start Claude Code in your project:
+
+```
+$ cd myproject && claude
+
+> /index ./src --namespace=backend
+Indexed 42 files into 'backend' collection
+
+> Find where we handle JWT validation
+Searching... Found 3 matches:
+  1. src/auth/jwt.ts (score: 0.94)
+  2. src/middleware/auth.ts (score: 0.87)
+  3. src/utils/token.ts (score: 0.72)
+
+> Show me the first one
+[Claude displays src/auth/jwt.ts with explanation]
+
+---
+
+> Index the src/ directory so you can search it semantically
+
+● logosdb_index_file({ path: "./src/auth/jwt.ts", namespace: "code" })
+  ✓ { indexed: 4, namespace: "code", file: "./src/auth/jwt.ts" }
+● logosdb_index_file({ path: "./src/middleware/auth.ts", namespace: "code" })
+  ✓ { indexed: 2, namespace: "code", file: "./src/middleware/auth.ts" }
+  … (42 files indexed)
+
+I've indexed the src/ directory into the "code" namespace — 42 files, 187 chunks.
+
+> Find where we validate JWT tokens
+
+● logosdb_search({ query: "JWT token validation", namespace: "code", top_k: 5 })
+  ✓ {
+      results: [
+        { score: 0.9431, file: "src/auth/jwt.ts",         text: "export function verifyToken(token) {…" },
+        { score: 0.8712, file: "src/middleware/auth.ts",   text: "const decoded = jwt.verify(req.headers…" },
+        { score: 0.8204, file: "src/utils/token.ts",       text: "function decodePayload(token: string)…"  },
+      ]
+    }
+
+The JWT validation logic lives in three places:
+1. **src/auth/jwt.ts** — `verifyToken()` is the main entry point (score 0.94)
+2. **src/middleware/auth.ts** — Express middleware that calls `verifyToken` on every request
+3. **src/utils/token.ts** — low-level payload decoder used by both
+
+> Remember that we decided to use RS256 instead of HS256 going forward
+
+● logosdb_index({ text: "Decision: use RS256 (asymmetric) instead of HS256 for JWT signing. Decided 2026-05-02.", namespace: "decisions" })
+  ✓ { id: 0, indexed: true, namespace: "decisions" }
+
+Noted. I'll keep that in the "decisions" namespace for future sessions.
+```
+
 ## Environment variables
 
 | Variable | Default | Description |

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -29,6 +29,85 @@ import { chunk } from './chunker.js';
 const LOGOSDB_PATH = process.env.LOGOSDB_PATH ?? path.join(process.cwd(), '.logosdb');
 const CHUNK_SIZE = parseInt(process.env.LOGOSDB_CHUNK_SIZE ?? '800', 10);
 
+// File extensions treated as indexable text
+const INDEXABLE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.go',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.cs',
+  '.rb',
+  '.php',
+  '.swift',
+  '.kt',
+  '.scala',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.fish',
+  '.md',
+  '.rst',
+  '.txt',
+  '.toml',
+  '.yaml',
+  '.yml',
+  '.json',
+  '.sql',
+  '.graphql',
+  '.proto',
+  '.env.example',
+  '.cfg',
+  '.ini',
+]);
+
+// Directories to skip when walking
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.venv',
+  '__pycache__',
+  '.next',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  '.turbo',
+]);
+
+function collectFiles(root: string): string[] {
+  const results: string[] = [];
+  function walk(dir: string) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') && entry.isDirectory()) continue;
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && INDEXABLE_EXTENSIONS.has(path.extname(entry.name))) {
+        results.push(full);
+      }
+    }
+  }
+  walk(root);
+  return results;
+}
+
 let embCfg: EmbeddingConfig;
 try {
   embCfg = resolveConfig();
@@ -67,12 +146,16 @@ const TOOLS: Tool[] = [
   {
     name: 'logosdb_index_file',
     description:
-      'Read a file from disk, chunk it, embed each chunk, and store all chunks in a namespace. ' +
+      'Read a file OR directory from disk, chunk each file, embed the chunks, and store them in a namespace. ' +
+      'When given a directory it walks recursively, skipping hidden paths and node_modules. ' +
       'Supports any UTF-8 text file (source code, markdown, plain text).',
     inputSchema: {
       type: 'object',
       properties: {
-        path: { type: 'string', description: 'Absolute or relative path to the file' },
+        path: {
+          type: 'string',
+          description: 'Absolute or relative path to a file or directory',
+        },
         namespace: { type: 'string', description: 'Collection name' },
         chunk_size: {
           type: 'number',
@@ -158,44 +241,59 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // ── logosdb_index_file ─────────────────────────────────────────────────
       case 'logosdb_index_file': {
-        const filePath = String(args.path ?? '');
+        const inputPath = String(args.path ?? '');
         const namespace = String(args.namespace ?? '');
         const chunkSize = typeof args.chunk_size === 'number' ? args.chunk_size : CHUNK_SIZE;
 
-        if (!filePath) throw new Error('"path" is required');
+        if (!inputPath) throw new Error('"path" is required');
         if (!namespace) throw new Error('"namespace" is required');
-
-        const absPath = path.resolve(filePath);
-        let content: string;
-        try {
-          content = fs.readFileSync(absPath, 'utf-8');
-        } catch {
-          throw new Error(`Cannot read file: ${absPath}`);
-        }
-
-        const chunks = chunk(content, chunkSize);
-        const texts = chunks.map((c) => c.text);
 
         ensureApiKey();
 
-        // Embed in batches of 96 (OpenAI limit per request)
+        const absPath = path.resolve(inputPath);
+        const stat = fs.statSync(absPath);
+        const filesToIndex = stat.isDirectory() ? collectFiles(absPath) : [absPath];
+
+        if (filesToIndex.length === 0) {
+          return ok({ indexed: 0, files: 0, namespace, path: absPath });
+        }
+
         const BATCH = 96;
-        const allVecs: number[][] = [];
-        for (let i = 0; i < texts.length; i += BATCH) {
-          const batch = texts.slice(i, i + BATCH);
-          const vecs = await embedBatch(batch, embCfg);
-          allVecs.push(...vecs);
-        }
-
-        const db = store.open(namespace, allVecs[0].length);
         const ts = new Date().toISOString();
-        const ids: number[] = [];
-        for (let i = 0; i < texts.length; i++) {
-          const label = `[file:${absPath}][chunk:${i}/${texts.length}] ${texts[i]}`;
-          ids.push(db.put(allVecs[i], label, ts));
+        let totalChunks = 0;
+        let firstVecLen = embCfg.dim;
+        let db: ReturnType<typeof store.open> | null = null;
+
+        for (const filePath of filesToIndex) {
+          let content: string;
+          try {
+            content = fs.readFileSync(filePath, 'utf-8');
+          } catch {
+            continue; // skip unreadable files
+          }
+
+          const fileChunks = chunk(content, chunkSize);
+          const texts = fileChunks.map((c) => c.text);
+
+          const allVecs: number[][] = [];
+          for (let i = 0; i < texts.length; i += BATCH) {
+            const batch = texts.slice(i, i + BATCH);
+            const vecs = await embedBatch(batch, embCfg);
+            allVecs.push(...vecs);
+          }
+
+          if (allVecs.length === 0) continue;
+          firstVecLen = allVecs[0].length;
+          if (!db) db = store.open(namespace, firstVecLen);
+
+          for (let i = 0; i < texts.length; i++) {
+            const label = `[file:${filePath}][chunk:${i}/${texts.length}] ${texts[i]}`;
+            db.put(allVecs[i], label, ts);
+          }
+          totalChunks += texts.length;
         }
 
-        return ok({ indexed: chunks.length, namespace, file: absPath });
+        return ok({ indexed: totalChunks, files: filesToIndex.length, namespace, path: absPath });
       }
 
       // ── logosdb_search ─────────────────────────────────────────────────────


### PR DESCRIPTION
```bash
$ cd myproject && claude

> /index ./src --namespace=backend
Indexed 42 files into 'backend' collection

> Find where we handle JWT validation
Searching... Found 3 matches:
  1. src/auth/jwt.ts (score: 0.94)
  2. src/middleware/auth.ts (score: 0.87)
  3. src/utils/token.ts (score: 0.72)

> Show me the first one
[Claude displays src/auth/jwt.ts with explanation]

> Remember that we decided to use RS256 instead of HS256 going forward

● logosdb_index({ text: "Decision: use RS256 (asymmetric) instead of HS256 for JWT signing. Decided 2026-05-02.", namespace: "decisions" })
  ✓ { id: 0, indexed: true, namespace: "decisions" }

Noted. I'll keep that in the "decisions" namespace for future sessions.
```


This pull request introduces comprehensive support for semantic code search workflows by adding slash commands, updating documentation, and enhancing the file indexing logic to support recursive directory indexing with file type filtering and directory skipping. The changes make it easier to index, search, and manage code and documentation files for semantic search, and provide clear user-facing commands and responses.

**Slash command and documentation improvements:**

* Added three new slash commands—`/index`, `/search`, and `/forget`—with detailed usage instructions and response formats in `.claude/commands/index.md`, `.claude/commands/search.md`, and `.claude/commands/forget.md`. These commands allow users to index files/directories, search semantically, and delete entries from LogosDB, respectively. [[1]](diffhunk://#diff-1843afae98ce0ce614623cc5c5174b59c5dc0d93f1e05f0073b7bdf4cbe4943dR1-R12) [[2]](diffhunk://#diff-92cc0a4faedfef3fd23e3b13bbea7f3e5646b262de28697c1a0959fd8ce54338R1-R19) [[3]](diffhunk://#diff-a9daf8dd0e9cdda3065bdcebf0960d6001e8733fc34b8139fef3ec1646cbe26fR1-R11)
* Updated `mcp/README.md` to document the new slash commands and provide an example session demonstrating semantic search and indexing workflows.

**Indexing logic enhancements:**

* Implemented a new `collectFiles` function in `mcp/src/index.ts` to recursively gather indexable files from a directory, filtering by a comprehensive set of code and text file extensions and skipping common build and environment directories.
* Updated the `logosdb_index_file` tool to accept directories as input, recursively index all supported files, skip hidden and excluded directories, and return the total number of files and chunks indexed. [[1]](diffhunk://#diff-e7c363de798b775c897dc7891919f6dfa493d4e76ccae1942e2d777443a0d8acL70-R158) [[2]](diffhunk://#diff-e7c363de798b775c897dc7891919f6dfa493d4e76ccae1942e2d777443a0d8acL161-R296)