### PR TITLE
feat(vibe): add /ldb-index /ldb-search /ldb-forget slash commands and example session

### DIFF
--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -42,4 +42,4 @@ permission = "ask"
 # ── Skills ───────────────────────────────────────────────────────────────────
 
 # Enables the logosdb-memory slash command and Python API documentation.
-enabled_skills = ["logosdb-memory"]
+enabled_skills = ["logosdb-memory", "ldb-index", "ldb-search", "ldb-forget"]

--- a/.vibe/skills/ldb-forget/SKILL.md
+++ b/.vibe/skills/ldb-forget/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ldb-forget
+description: Delete an entry from LogosDB by row ID or by semantic query match.
+user-invocable: true
+allowed-tools:
+  - bash
+---
+
+Delete entries from LogosDB using the logosdb-vibe CLI.
+
+Parse the user's arguments:
+- `--namespace=<name>` or `-n <name>` sets the collection (default: `code`)
+- `--id=<number>` deletes by row ID
+- `--query=<text>` or `-q <text>` deletes the closest semantic match
+
+Run exactly one of:
+```
+logosdb-vibe forget --namespace <namespace> --id <id>
+logosdb-vibe forget --namespace <namespace> --query "<query>"
+```
+
+Then respond: Deleted {n} entr{y/ies} from '{namespace}' namespace.

--- a/.vibe/skills/ldb-index/SKILL.md
+++ b/.vibe/skills/ldb-index/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ldb-index
+description: Index a file or directory into LogosDB for semantic search across Vibe sessions.
+user-invocable: true
+allowed-tools:
+  - bash
+---
+
+Index files into LogosDB using the logosdb-vibe CLI.
+
+Parse the user's arguments:
+- First positional argument is the path to index (file or directory)
+- `--namespace=<name>` or `-n <name>` sets the collection (default: `code`)
+
+Run exactly:
+```
+logosdb-vibe index <path> --namespace <namespace>
+```
+
+Then respond in this exact format (no extra prose):
+Indexed {files} files into '{namespace}' collection

--- a/.vibe/skills/ldb-search/SKILL.md
+++ b/.vibe/skills/ldb-search/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: ldb-search
+description: Semantic search over an indexed LogosDB namespace.
+user-invocable: true
+allowed-tools:
+  - bash
+---
+
+Search LogosDB using the logosdb-vibe CLI.
+
+Parse the user's arguments:
+- Everything before any flag is the search query (quote it)
+- `--namespace=<name>` or `-n <name>` sets the collection (default: `code`)
+- `--top-k=<n>` or `-k <n>` sets result count (default: 5)
+
+Run exactly:
+```
+logosdb-vibe search "<query>" --namespace <namespace> --top-k <top_k>
+```
+
+The CLI returns JSON. Parse it and present results in this format:
+Searching... Found {N} matches:
+  1. {file} (score: {score})
+  2. {file} (score: {score})
+  ...
+
+Extract the file path from the `file` field in each result.
+If the list is empty, respond: No matches found in '{namespace}' namespace.

--- a/.vibe/skills/logosdb-memory/SKILL.md
+++ b/.vibe/skills/logosdb-memory/SKILL.md
@@ -32,15 +32,46 @@ LOGOSDB_PATH=./.logosdb
 MISTRAL_API_KEY=your_key_here
 ```
 
-## Slash command usage (inside Vibe)
+## Slash commands (inside Vibe)
+
+Three focused slash commands are available once this skill is enabled:
+
+| Command | Example |
+|---|---|
+| `/ldb-index` | `/ldb-index ./src --namespace=backend` |
+| `/ldb-search` | `/ldb-search "JWT validation" --namespace=backend` |
+| `/ldb-forget` | `/ldb-forget --namespace=backend --id=42` |
+
+### Example session
 
 ```
-/logosdb-memory index ./src --namespace code
-/logosdb-memory search "where is JWT validated" --namespace code --top-k 5
-/logosdb-memory forget --namespace code --query "old feature"
-/logosdb-memory info
-/logosdb-memory list
+$ cd myproject && vibe
+
+> /ldb-index ./src --namespace=backend
+Indexed 42 files into 'backend' collection
+
+> Find where we handle JWT validation
+Searching... Found 3 matches:
+  1. src/auth/jwt.ts (score: 0.94)
+  2. src/middleware/auth.ts (score: 0.87)
+  3. src/utils/token.ts (score: 0.72)
+
+> Show me the first one
+[Vibe displays src/auth/jwt.ts with explanation]
+
+> /ldb-search "retry logic" --namespace=backend --top-k=3
+Searching... Found 3 matches:
+  1. src/utils/retry.ts (score: 0.91)
+  2. src/api/client.ts (score: 0.83)
+  3. src/jobs/queue.ts (score: 0.77)
+
+> /ldb-forget --namespace=backend --id=42
+Deleted 1 entry from 'backend' namespace.
 ```
+
+Natural-language queries (`> Find where we...`) also work without a slash command
+— Vibe calls `logosdb-vibe search` automatically when it understands you are
+asking about the indexed codebase.
 
 ## Standalone CLI
 


### PR DESCRIPTION
This pull request adds three new focused skills for interacting with LogosDB (indexing, searching, and forgetting entries) and updates the configuration and documentation to support them. These changes improve usability by providing clear, user-invocable slash commands with dedicated documentation and examples.

**Skill additions and documentation:**

* Added new skills: `ldb-index`, `ldb-search`, and `ldb-forget`, each with its own `SKILL.md` describing usage, arguments, and expected responses. These skills enable users to index files, perform semantic search, and delete entries from LogosDB using simple commands. [[1]](diffhunk://#diff-1dc3778b216012c8696152abea0804f9b93978fee6805a6a5f7a1dcfa9a3d263R1-R21) [[2]](diffhunk://#diff-28724d05260bfdcd2f45eedaeeda0f4491ee332f493b9b92e75aad1c025b6b50R1-R28) [[3]](diffhunk://#diff-e968fe049217bcf224e856483e49777c313bd45a5d2db59ad1a308226fa5a065R1-R22)
* Updated the `logosdb-memory` skill documentation to introduce and demonstrate the new slash commands (`/ldb-index`, `/ldb-search`, `/ldb-forget`) with example sessions, making it easier for users to understand and use these features.

**Configuration updates:**

* Enabled the new skills in `.vibe/config.toml` by adding them to the `enabled_skills` array, making them available for use in Vibe.… example session