### PR TITLE
chore(release): bump core and packages to 0.7.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(logosdb VERSION 0.7.1 LANGUAGES CXX)
+project(logosdb VERSION 0.7.4 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/logosdb/logosdb.h
+++ b/include/logosdb/logosdb.h
@@ -7,7 +7,7 @@
 #define LOGOSDB_VERSION_MAJOR 0
 #define LOGOSDB_VERSION_MINOR 7
 #define LOGOSDB_VERSION_PATCH 0
-#define LOGOSDB_VERSION_STRING "0.7.1"
+#define LOGOSDB_VERSION_STRING "0.7.4"
 
 /* Distance metrics for vector similarity search */
 #define LOGOSDB_DIST_IP      0  /* Inner product (default, requires L2-normalized vectors) */

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "logosdb-mcp-server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logosdb-mcp-server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xenova/transformers": "^2.17.2",
-        "logosdb": "^0.7.1"
+        "logosdb": "^0.7.4"
       },
       "bin": {
         "logosdb-mcp-server": "dist/index.js"
@@ -110,7 +110,7 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
+      "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
       "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
@@ -990,7 +990,7 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
+      "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
@@ -1833,7 +1833,7 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
+      "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
@@ -2035,8 +2035,8 @@
       }
     },
     "node_modules/logosdb": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/logosdb/-/logosdb-0.7.1.tgz",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/logosdb/-/logosdb-0.7.4.tgz",
       "integrity": "sha512-fAu+rrIXQMzi05QRNf+v9zu9vvApivxupaD7xijBfC8jsZDhox6QiEHYou/oidL34ikgrIx0hju3IDjaDNGaBg==",
       "cpu": [
         "x64",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xenova/transformers": "^2.17.2",
-    "logosdb": "^0.7.1"
+    "logosdb": "^0.7.4"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -223,7 +223,7 @@ const TOOLS: Tool[] = [
 
 // ── Server ────────────────────────────────────────────────────────────────────
 
-const server = new Server({ name: 'logosdb', version: '0.7.3' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'logosdb', version: '0.7.4' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "n8n-nodes-logosdb",
-  "version": "0.7.1",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-logosdb",
-      "version": "0.7.1",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
-        "logosdb": "^0.7.1"
+        "logosdb": "^0.7.4"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -2166,8 +2166,8 @@
       "license": "MIT"
     },
     "node_modules/logosdb": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/logosdb/-/logosdb-0.7.1.tgz",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/logosdb/-/logosdb-0.7.4.tgz",
       "integrity": "sha512-fAu+rrIXQMzi05QRNf+v9zu9vvApivxupaD7xijBfC8jsZDhox6QiEHYou/oidL34ikgrIx0hju3IDjaDNGaBg==",
       "cpu": [
         "x64",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-logosdb",
-  "version": "0.7.1",
+  "version": "0.7.4",
   "description": "n8n node for LogosDB semantic vector database — insert, search, delete, info",
   "keywords": [
     "n8n-community-node-package",
@@ -41,7 +41,7 @@
     ]
   },
   "dependencies": {
-    "logosdb": "^0.7.1"
+    "logosdb": "^0.7.4"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logosdb",
-  "version": "0.7.1",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logosdb",
-      "version": "0.7.1",
+      "version": "0.7.4",
       "cpu": [
         "x64",
         "arm64"
@@ -289,7 +289,7 @@
       "license": "MIT"
     },
     "node_modules/aws-sign2": {
-      "version": "0.7.0",
+      "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Fast semantic vector database (HNSW + mmap) - Node.js bindings",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "logosdb"
-version = "0.7.3"
+version = "0.7.4"
 description = "Fast semantic vector database (HNSW + mmap) with Python bindings"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Release bump to 0.7.4 across core and package surfaces (python, nodejs, mcp, n8n).