### PR TITLE
chore(release): temporary ^0.7.3 pin for mcp/n8n while 0.7.4 publishes

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xenova/transformers": "^2.17.2",
-        "logosdb": "^0.7.4"
+        "logosdb": "^0.7.3"
       },
       "bin": {
         "logosdb-mcp-server": "dist/index.js"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xenova/transformers": "^2.17.2",
-    "logosdb": "^0.7.4"
+    "logosdb": "^0.7.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
-        "logosdb": "^0.7.4"
+        "logosdb": "^0.7.3"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "dependencies": {
-    "logosdb": "^0.7.4"
+    "logosdb": "^0.7.3"
   },
   "devDependencies": {
     "typescript": "^5.4.0",


### PR DESCRIPTION
Temporary release ordering fix: keep mcp/n8n dependency on logosdb ^0.7.3 to avoid npm 404, then follow with a dependency bump PR after logosdb@0.7.4 is live.