### PR TITLE
chore(release): bump core packages to 0.7.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(logosdb VERSION 0.7.4 LANGUAGES CXX)
+project(logosdb VERSION 0.7.5 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/logosdb/logosdb.h
+++ b/include/logosdb/logosdb.h
@@ -6,8 +6,8 @@
 
 #define LOGOSDB_VERSION_MAJOR 0
 #define LOGOSDB_VERSION_MINOR 7
-#define LOGOSDB_VERSION_PATCH 0
-#define LOGOSDB_VERSION_STRING "0.7.4"
+#define LOGOSDB_VERSION_PATCH 5
+#define LOGOSDB_VERSION_STRING "0.7.5"
 
 /* Distance metrics for vector similarity search */
 #define LOGOSDB_DIST_IP      0  /* Inner product (default, requires L2-normalized vectors) */

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xenova/transformers": "^2.17.2",
-        "logosdb": "^0.7.3"
+        "logosdb": "^0.7.4"
       },
       "bin": {
         "logosdb-mcp-server": "dist/index.js"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xenova/transformers": "^2.17.2",
-    "logosdb": "^0.7.3"
+    "logosdb": "^0.7.4"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
-        "logosdb": "^0.7.3"
+        "logosdb": "^0.7.4"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "dependencies": {
-    "logosdb": "^0.7.3"
+    "logosdb": "^0.7.4"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logosdb",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logosdb",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "cpu": [
         "x64",
         "arm64"
@@ -289,7 +289,7 @@
       "license": "MIT"
     },
     "node_modules/aws-sign2": {
-      "version": "0.7.4",
+      "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Fast semantic vector database (HNSW + mmap) - Node.js bindings",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "logosdb"
-version = "0.7.4"
+version = "0.7.5"
 description = "Fast semantic vector database (HNSW + mmap) with Python bindings"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Bumps core release surfaces (python, C++ core, nodejs binding) to 0.7.5.