### PR TITLE
docs(community): add CONTRIBUTING, templates, SECURITY, CoC (#16)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,57 @@
+---
+name: Bug report
+about: Create a report to help us improve LogosDB
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Build with '...'
+2. Run '...'
+3. See error
+
+Minimal code example:
+
+```cpp
+// C/C++ example
+#include <logosdb/logosdb.h>
+// ... reproduce code
+```
+
+Or Python:
+
+```python
+import logosdb
+# ... reproduce code
+```
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened, including error messages, stack traces, or output.
+
+## Environment
+
+- OS: [e.g., Ubuntu 22.04, macOS 14, Windows 11]
+- Compiler: [e.g., GCC 12, Clang 15, MSVC 2022]
+- CMake version: [e.g., 3.27]
+- LogosDB version or commit: [e.g., v0.7.0 or commit hash]
+- Python version (if using bindings): [e.g., 3.11]
+
+## Additional context
+
+Add any other context about the problem here, such as:
+- Does it happen consistently or intermittently?
+- Workarounds you've found
+- Related issues

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,49 @@
+---
+name: Feature request
+about: Suggest an idea for LogosDB
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A clear and concise description of what you want to happen.
+
+## Motivation
+
+Why is this needed? What problem does it solve?
+
+- Current limitation or pain point
+- Use case or scenario
+- Who would benefit
+
+## Proposed solution
+
+Describe the solution you'd like. Be specific about:
+
+- API changes (C/C++/Python)
+- CLI additions
+- Configuration options
+- Performance implications
+
+## Alternatives considered
+
+What alternatives have you considered? Why is this approach better?
+
+## Additional context
+
+- Links to related issues or PRs
+- References to similar features in other databases
+- Mockups or sketches (if applicable)
+
+## Acceptance criteria
+
+What would make this feature "done"?
+
+- [ ] C API added/updated
+- [ ] C++ wrapper updated
+- [ ] Python bindings updated
+- [ ] Tests added
+- [ ] Documentation updated
+- [ ] CHANGELOG entry added

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Summary
+
+Brief description of what this PR does.
+
+Closes #(issue number)
+
+## Changes
+
+- [ ] Feature A
+- [ ] Fix B
+- [ ] Refactor C
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Refactoring (no functional changes)
+
+## Testing
+
+- [ ] Unit tests added/updated
+- [ ] Integration tests pass
+- [ ] Manual testing performed
+
+Describe the tests you ran:
+
+## Checklist
+
+- [ ] Code compiles without warnings on GCC and Clang
+- [ ] Tests pass (`ctest --output-on-failure`, `pytest`)
+- [ ] Benchmarks run if performance-related
+- [ ] CHANGELOG updated for user-facing changes
+- [ ] Documentation updated (README, headers, guides)
+- [ ] PR title follows conventional commit style (`feat:`, `fix:`, `docs:`, etc.)
+
+## Additional Notes
+
+Any other notes for reviewers:
+
+- Design decisions
+- Trade-offs
+- Migration steps (if breaking change)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+github@joseignacio.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,177 @@
+# Contributing to LogosDB
+
+Thank you for your interest in contributing to LogosDB. This document outlines the workflow, style expectations, and how to get started.
+
+## Quick Start
+
+### Prerequisites
+
+- CMake 3.16+ (3.20+ recommended)
+- C++17-capable compiler (GCC 9+, Clang 12+, Apple Clang 13+, MSVC 2019+)
+- Python 3.9+ (for Python bindings and tests)
+- Git with submodule support
+
+### Building
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules https://github.com/jose-compu/logosdb.git
+cd logosdb
+
+# Configure and build
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . --parallel
+
+# Or with Ninja (faster)
+cmake -DCMAKE_BUILD_TYPE=Release -G Ninja ..
+ninja
+```
+
+Build targets:
+- `logosdb` — static library (`liblogosdb.a`)
+- `logosdb-cli` — command-line tool
+- `logosdb-bench` — benchmark utility
+- `logosdb-test` — unit tests
+
+### Running Tests
+
+```bash
+cd build
+
+# Run C++ tests
+ctest --output-on-failure
+
+# Run Python tests
+pip install ".[test]"
+pytest tests/python/
+```
+
+### Running the Benchmark
+
+```bash
+cd build
+./logosdb-bench --dim 2048 --counts 1000,10000,100000
+```
+
+## Code Style
+
+We follow these conventions:
+
+- **C/C++**: Google C++ Style Guide (roughly)
+  - 4-space indentation
+  - `snake_case` for functions/variables
+  - `PascalCase` for classes
+  - `SCREAMING_SNAKE_CASE` for macros/constants
+  - Braces on same line
+- **Python**: PEP 8 with 4-space indentation
+- **Filenames**: `snake_case.cpp`, `snake_case.h`
+
+See [Issue #12](https://github.com/jose-compu/logosdb/issues/12) for ongoing work on automated formatting (clang-format).
+
+### Style Guidelines
+
+- Keep functions focused and under 50 lines when possible
+- Prefer RAII and smart pointers; avoid raw `new/delete`
+- Use `const` and `constexpr` aggressively
+- Document public API in header files with brief comments
+- Internal code: comments explain "why", not "what"
+
+## Branch and PR Workflow
+
+1. **Fork** the repository (or create a branch if you have access)
+2. **Branch naming**: `feature/description`, `fix/description`, `docs/description`
+3. **Commit messages**: Follow conventional commits style
+   - `feat: add batch ingest API`
+   - `fix: handle zero-dim vectors gracefully`
+   - `docs: update sizing guide with int8 numbers`
+4. **Pull Request**: Fill out the PR template checklist
+5. **CI**: Ensure all checks pass (build + tests on Linux/macOS)
+
+### PR Checklist
+
+Before submitting:
+
+- [ ] Tests added for new functionality
+- [ ] Existing tests pass (`ctest`, `pytest`)
+- [ ] Benchmarks run if performance-related
+- [ ] CHANGELOG updated for user-facing changes
+- [ ] Documentation updated (README, headers, guides)
+- [ ] Code compiles without warnings on GCC and Clang
+
+## Development Setup Tips
+
+### CMake Presets (optional)
+
+Create `CMakeUserPresets.json` for local development:
+
+```json
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "dev",
+      "generator": "Ninja",
+      "binaryDir": "build-dev",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ]
+}
+```
+
+### IDE Integration
+
+- **VS Code**: Install CMake Tools and C/C++ extensions
+- **CLion**: Open the project root; CMake is auto-detected
+- **vim/neovim**: Use `compile_commands.json` from CMake for LSP
+
+### Python Development
+
+```bash
+# Editable install for Python work
+pip install -e ".[test,examples]"
+
+# Run specific test
+pytest tests/python/test_smoke.py -v
+```
+
+## Testing Guidelines
+
+### C++ Tests
+
+- Add tests in `tests/` directory
+- Use existing test patterns in `tests/test_basic.cpp`
+- Tests run via CTest; add with `add_test()` in CMake
+
+### Python Tests
+
+- Use `pytest`
+- Tests in `tests/python/`
+- Mock external services; keep tests fast and deterministic
+
+### Test Coverage
+
+Aim for:
+- New features: unit tests covering edge cases
+- Bug fixes: regression test that would have caught the bug
+- API changes: tests for C and C++ wrappers
+
+## Documentation
+
+- **Public headers**: Document in Doxygen style (brief, params, returns)
+- **README.md**: Update for user-facing changes
+- **docs/**: Long-form guides (sizing, RAG patterns, etc.)
+- **Changelog**: Add entry under appropriate version in CHANGELOG
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Use the issue templates (bug report, feature request)
+- For security issues, see [SECURITY.md](SECURITY.md)
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ LogosDB is a fast semantic vector database written in C/C++ that provides approx
 
 Authors: Jose ([@jose-compu](https://github.com/jose-compu))
 
+**Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions, style guide, and PR workflow.
+
 # Features
 
   * Vectors and metadata are stored as flat binary files, memory-mapped for zero-copy reads.
@@ -569,6 +571,15 @@ LogosDB uses the same HNSW implementation as ChromaDB (hnswlib) but eliminates P
     .claude/mcp.json              Example Claude Code MCP configuration
     CHANGELOG                     Release history
     LICENSE                       MIT license text
+
+# Contributing
+
+We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for:
+- Building from source
+- Running tests and benchmarks
+- Code style and PR workflow
+
+Please review our [Code of Conduct](CODE_OF_CONDUCT.md) and [Security Policy](SECURITY.md).
 
 # License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported Versions
+
+We release security updates for the latest minor version series. Please keep your LogosDB installation up to date.
+
+| Version | Supported          |
+|---------| ------------------ |
+| 0.7.x   | :white_check_mark: |
+| < 0.7   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in LogosDB, please report it responsibly:
+
+**Email**: security@logosdb.dev (or the repository owner's contact if this is a fork)
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce (if applicable)
+- Potential impact assessment
+- Suggested fix (if you have one)
+
+We aim to:
+- Acknowledge receipt within 48 hours
+- Provide a timeline for a fix within 7 days
+- Coordinate disclosure once a patch is available
+
+## What to Report
+
+Security issues include but are not limited to:
+
+- Memory safety issues (buffer overflows, use-after-free)
+- Injection vulnerabilities in CLI or MCP server
+- Path traversal or file system issues
+- Denial of service via malformed inputs
+- Information disclosure via logs or error messages
+
+## What NOT to Report
+
+- General bugs (use [Issues](https://github.com/jose-compu/logosdb/issues) instead)
+- Feature requests (use [Issues](https://github.com/jose-compu/logosdb/issues) instead)
+- Performance issues (unless they constitute DoS)
+
+## Best Practices for Users
+
+- Keep LogosDB updated to the latest version
+- Run with minimal privileges
+- Validate inputs when embedding LogosDB in larger systems
+- Review MCP server configuration for your threat model
+
+## Disclosure Policy
+
+We follow a coordinated disclosure approach:
+
+1. Report received and acknowledged
+2. Fix developed and tested
+3. Patch released
+4. Public disclosure after users have time to update
+
+We appreciate responsible disclosure and will credit reporters (with permission) in release notes.


### PR DESCRIPTION
Add community documentation and GitHub templates:

- CONTRIBUTING.md: build, test, style, and PR workflow guide
- SECURITY.md: vulnerability reporting policy
- CODE_OF_CONDUCT.md: Contributor Covenant v2.1
- .github/ISSUE_TEMPLATE/: bug_report.md and feature_request.md
- .github/PULL_REQUEST_TEMPLATE.md: PR checklist
- README.md: Contributing section with cross-links

Closes #16