### PR TITLE
build: add .clang-format, .clang-tidy, .editorconfig and CI checks (#12)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,78 @@
+---
+# LogosDB C/C++ formatting style
+# Based on LLVM style with adjustments for existing codebase conventions
+
+Language: Cpp
+BasedOnStyle: LLVM
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+# Braces (Allman style - braces on their own line)
+BreakBeforeBraces: Allman
+
+# Line length
+ColumnLimit: 100
+
+# Alignment
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+# Function declarations/definitions
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortLambdasOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+
+# Parameters and arguments
+BinPackArguments: false
+BinPackParameters: false
+PackConstructorInitializers: Never
+
+# Constructor initializers
+BreakConstructorInitializers: BeforeColon
+
+# Control statements
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+# Namespaces
+NamespaceIndentation: None
+FixNamespaceComments: true
+
+# Includes
+IncludeBlocks: Regroup
+SortIncludes: true
+IncludeCategories:
+  - Regex:           '^<logosdb/'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        3
+  - Regex:           '^<.*'
+    Priority:        4
+  - Regex:           '.*'
+    Priority:        1
+
+# Pointer alignment
+PointerAlignment: Left
+
+# Other
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+ReflowComments: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+tests/doctest.h
+third_party/

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,64 @@
+---
+# LogosDB clang-tidy configuration
+# Conservative rule set focused on correctness and performance
+
+Checks: >
+  bugprone-*,
+  performance-*,
+  readability-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-narrowing-conversions,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-vararg,
+  -modernize-avoid-c-arrays,
+  -modernize-use-trailing-return-type,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-simplify-boolean-expr,
+  -readability-uppercase-literal-suffix,
+
+CheckOptions:
+  - key:   readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key:   readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key:   readability-identifier-naming.FunctionCase
+    value: lower_case
+  - key:   readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key:   readability-identifier-naming.MemberCase
+    value: lower_case
+  - key:   readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key:   readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key:   readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key:   readability-identifier-naming.StructCase
+    value: CamelCase
+  - key:   readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key:   readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key:   readability-identifier-naming.UnionCase
+    value: CamelCase
+  - key:   readability-identifier-naming.VariableCase
+    value: lower_case
+  - key:   readability-braces-around-statements.ShortStatementLines
+    value: '1'
+
+HeaderFilterRegex: '(include|src)/.*\.h$'
+FormatStyle: file
+User: logosdb

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,57 @@
+# LogosDB EditorConfig
+# EditorConfig helps maintain consistent coding styles across editors
+# http://editorconfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# C/C++ files
+[*.{h,hpp,c,cpp}]
+indent_style = space
+indent_size = 4
+tab_width = 4
+max_line_length = 100
+
+# CMake files
+[{CMakeLists.txt,*.cmake}]
+indent_style = space
+indent_size = 4
+
+# Python files
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+# YAML files (GitHub Actions, etc.)
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+max_line_length = 120
+
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2
+
+# Makefiles
+[{Makefile,*.mk}]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,8 @@ jobs:
 
       - name: Run clang-format check
         run: |
-          find src include tests tools -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | \
+          find src include tests tools \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) | \
+            grep -v 'doctest.h' | \
             xargs clang-format --dry-run -Werror
 
       - name: Run clang-tidy check (optional, report only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,35 @@ jobs:
         run: |
           rm -rf /tmp/ci-smoke-db
           ./logosdb-cli info /tmp/ci-smoke-db --dim 16
+
+  # Formatting and linting check (Linux only, single config)
+  format-check:
+    name: Formatting / Linting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install clang-format and clang-tidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang-format clang-tidy
+
+      - name: Check clang-format version
+        run: clang-format --version
+
+      - name: Run clang-format check
+        run: |
+          find src include tests tools -name '*.cpp' -o -name '*.h' -o -name '*.hpp' | \
+            xargs clang-format --dry-run -Werror
+
+      - name: Run clang-tidy check (optional, report only)
+        run: |
+          mkdir -p build
+          cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          find src -name '*.cpp' | \
+            xargs clang-tidy -p build --warnings-as-errors='' 2>&1 || true
+        continue-on-error: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,10 @@ We follow these conventions:
 - **Python**: PEP 8 with 4-space indentation
 - **Filenames**: `snake_case.cpp`, `snake_case.h`
 
-See [Issue #12](https://github.com/jose-compu/logosdb/issues/12) for ongoing work on automated formatting (clang-format).
+**Formatting tools available:**
+- Run `clang-format -i src/yourfile.cpp` to auto-format C/C++ code
+- Run `clang-tidy src/yourfile.cpp` to check for common issues
+- CI enforces formatting via `clang-format --dry-run -Werror`
 
 ### Style Guidelines
 

--- a/include/logosdb/logosdb.h
+++ b/include/logosdb/logosdb.h
@@ -10,175 +10,179 @@
 #define LOGOSDB_VERSION_STRING "0.7.5"
 
 /* Distance metrics for vector similarity search */
-#define LOGOSDB_DIST_IP      0  /* Inner product (default, requires L2-normalized vectors) */
-#define LOGOSDB_DIST_COSINE  1  /* Cosine similarity (auto-normalizes vectors) */
-#define LOGOSDB_DIST_L2      2  /* Euclidean distance (L2 space) */
+#define LOGOSDB_DIST_IP 0     /* Inner product (default, requires L2-normalized vectors) */
+#define LOGOSDB_DIST_COSINE 1 /* Cosine similarity (auto-normalizes vectors) */
+#define LOGOSDB_DIST_L2 2     /* Euclidean distance (L2 space) */
 
 /* Storage data types for reduced-precision vector storage */
-#define LOGOSDB_DTYPE_FLOAT32 0  /* 4 bytes per dimension (default) */
-#define LOGOSDB_DTYPE_FLOAT16 1  /* 2 bytes per dimension, ~50% smaller */
-#define LOGOSDB_DTYPE_INT8    2  /* 1 byte per dimension, ~75% smaller */
+#define LOGOSDB_DTYPE_FLOAT32 0 /* 4 bytes per dimension (default) */
+#define LOGOSDB_DTYPE_FLOAT16 1 /* 2 bytes per dimension, ~50% smaller */
+#define LOGOSDB_DTYPE_INT8 2    /* 1 byte per dimension, ~75% smaller */
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* ── Opaque handles ────────────────────────────────────────────────── */
+    /* ── Opaque handles ────────────────────────────────────────────────── */
 
-typedef struct logosdb_t              logosdb_t;
-typedef struct logosdb_options_t      logosdb_options_t;
-typedef struct logosdb_search_result_t logosdb_search_result_t;
+    typedef struct logosdb_t logosdb_t;
+    typedef struct logosdb_options_t logosdb_options_t;
+    typedef struct logosdb_search_result_t logosdb_search_result_t;
 
-/* ── Options ───────────────────────────────────────────────────────── */
+    /* ── Options ───────────────────────────────────────────────────────── */
 
-logosdb_options_t * logosdb_options_create(void);
-void logosdb_options_destroy(logosdb_options_t * opts);
+    logosdb_options_t* logosdb_options_create(void);
+    void logosdb_options_destroy(logosdb_options_t* opts);
 
-void logosdb_options_set_dim(logosdb_options_t * opts, int dim);
-void logosdb_options_set_max_elements(logosdb_options_t * opts, size_t n);
-void logosdb_options_set_ef_construction(logosdb_options_t * opts, int ef);
-void logosdb_options_set_M(logosdb_options_t * opts, int M);
-void logosdb_options_set_ef_search(logosdb_options_t * opts, int ef);
+    void logosdb_options_set_dim(logosdb_options_t* opts, int dim);
+    void logosdb_options_set_max_elements(logosdb_options_t* opts, size_t n);
+    void logosdb_options_set_ef_construction(logosdb_options_t* opts, int ef);
+    void logosdb_options_set_M(logosdb_options_t* opts, int M);
+    void logosdb_options_set_ef_search(logosdb_options_t* opts, int ef);
 
-/* Set distance metric for vector similarity.
- *   metric: one of LOGOSDB_DIST_IP, LOGOSDB_DIST_COSINE, or LOGOSDB_DIST_L2
- *           (default is LOGOSDB_DIST_IP)
- *
- * For LOGOSDB_DIST_IP: vectors must be L2-normalized by caller.
- * For LOGOSDB_DIST_COSINE: vectors are automatically L2-normalized on put/search.
- * For LOGOSDB_DIST_L2: Euclidean distance is used (lower is more similar).
- *
- * The distance metric is persisted in the index file and must match on reopen.
- * Returns 0 on success, -1 on invalid metric. */
-int logosdb_options_set_distance(logosdb_options_t * opts, int metric);
+    /* Set distance metric for vector similarity.
+     *   metric: one of LOGOSDB_DIST_IP, LOGOSDB_DIST_COSINE, or LOGOSDB_DIST_L2
+     *           (default is LOGOSDB_DIST_IP)
+     *
+     * For LOGOSDB_DIST_IP: vectors must be L2-normalized by caller.
+     * For LOGOSDB_DIST_COSINE: vectors are automatically L2-normalized on put/search.
+     * For LOGOSDB_DIST_L2: Euclidean distance is used (lower is more similar).
+     *
+     * The distance metric is persisted in the index file and must match on reopen.
+     * Returns 0 on success, -1 on invalid metric. */
+    int logosdb_options_set_distance(logosdb_options_t* opts, int metric);
 
-/* Set storage data type for reduced-precision vector storage.
- *   dtype: one of LOGOSDB_DTYPE_FLOAT32, LOGOSDB_DTYPE_FLOAT16, or LOGOSDB_DTYPE_INT8
- *          (default is LOGOSDB_DTYPE_FLOAT32)
- *
- * This affects how vectors are stored on disk:
- * - FLOAT32: Full precision, 4 bytes per dimension
- * - FLOAT16: Half precision, 2 bytes per dimension (~50% smaller)
- * - INT8:    8-bit quantized, 1 byte per dimension (~75% smaller)
- *
- * Vectors are always dequantized to float32 for HNSW search.
- * The dtype is persisted in the storage file and must match on reopen.
- * Returns 0 on success, -1 on invalid dtype. */
-int logosdb_options_set_dtype(logosdb_options_t * opts, int dtype);
+    /* Set storage data type for reduced-precision vector storage.
+     *   dtype: one of LOGOSDB_DTYPE_FLOAT32, LOGOSDB_DTYPE_FLOAT16, or LOGOSDB_DTYPE_INT8
+     *          (default is LOGOSDB_DTYPE_FLOAT32)
+     *
+     * This affects how vectors are stored on disk:
+     * - FLOAT32: Full precision, 4 bytes per dimension
+     * - FLOAT16: Half precision, 2 bytes per dimension (~50% smaller)
+     * - INT8:    8-bit quantized, 1 byte per dimension (~75% smaller)
+     *
+     * Vectors are always dequantized to float32 for HNSW search.
+     * The dtype is persisted in the storage file and must match on reopen.
+     * Returns 0 on success, -1 on invalid dtype. */
+    int logosdb_options_set_dtype(logosdb_options_t* opts, int dtype);
 
-/* ── Lifecycle ─────────────────────────────────────────────────────── */
+    /* ── Lifecycle ─────────────────────────────────────────────────────── */
 
-logosdb_t * logosdb_open(const char * path, const logosdb_options_t * opts,
-                         char ** errptr);
-void        logosdb_close(logosdb_t * db);
+    logosdb_t* logosdb_open(const char* path, const logosdb_options_t* opts, char** errptr);
+    void logosdb_close(logosdb_t* db);
 
-/* ── Write ─────────────────────────────────────────────────────────── */
+    /* ── Write ─────────────────────────────────────────────────────────── */
 
-uint64_t logosdb_put(logosdb_t * db,
-                     const float * embedding, int dim,
-                     const char * text,
-                     const char * timestamp,
-                     char ** errptr);
+    uint64_t logosdb_put(logosdb_t* db,
+                         const float* embedding,
+                         int dim,
+                         const char* text,
+                         const char* timestamp,
+                         char** errptr);
 
-/* Batch insert of N vectors. More efficient than N separate logosdb_put calls.
- *   embeddings: flattened (n x dim) float array
- *   texts, timestamps: arrays of n pointers (may be NULL)
- *   out_ids: pre-allocated array of size n to receive assigned row ids
- *
- * Returns 0 on success, -1 on error (partial insert may have occurred).
- * On error, *errptr is set to a newly-allocated message that the caller
- * must free(). */
-int logosdb_put_batch(logosdb_t * db,
-                      const float * embeddings, int n, int dim,
-                      const char * const * texts,
-                      const char * const * timestamps,
-                      uint64_t * out_ids,
-                      char ** errptr);
+    /* Batch insert of N vectors. More efficient than N separate logosdb_put calls.
+     *   embeddings: flattened (n x dim) float array
+     *   texts, timestamps: arrays of n pointers (may be NULL)
+     *   out_ids: pre-allocated array of size n to receive assigned row ids
+     *
+     * Returns 0 on success, -1 on error (partial insert may have occurred).
+     * On error, *errptr is set to a newly-allocated message that the caller
+     * must free(). */
+    int logosdb_put_batch(logosdb_t* db,
+                          const float* embeddings,
+                          int n,
+                          int dim,
+                          const char* const* texts,
+                          const char* const* timestamps,
+                          uint64_t* out_ids,
+                          char** errptr);
 
-/* Mark the row with the given id as deleted. The vector bytes remain on
- * disk but the row is excluded from search results and future `raw_vectors`
- * bulk views (logosdb_count_live reflects live rows only).
- *
- * Returns 0 on success, -1 on error (id out of range, already deleted,
- * db not open). On error `*errptr` is set to a newly-allocated message
- * that the caller must free(). */
-int logosdb_delete(logosdb_t * db, uint64_t id, char ** errptr);
+    /* Mark the row with the given id as deleted. The vector bytes remain on
+     * disk but the row is excluded from search results and future `raw_vectors`
+     * bulk views (logosdb_count_live reflects live rows only).
+     *
+     * Returns 0 on success, -1 on error (id out of range, already deleted,
+     * db not open). On error `*errptr` is set to a newly-allocated message
+     * that the caller must free(). */
+    int logosdb_delete(logosdb_t* db, uint64_t id, char** errptr);
 
-/* Replace the row with the given id. This is implemented as a
- * delete-then-put, so the returned id is NEW (not the original `id`).
- * Callers must update any stored references.
- *
- * Returns the new id on success, UINT64_MAX on error. */
-uint64_t logosdb_update(logosdb_t * db, uint64_t id,
-                        const float * embedding, int dim,
-                        const char * text,
-                        const char * timestamp,
-                        char ** errptr);
+    /* Replace the row with the given id. This is implemented as a
+     * delete-then-put, so the returned id is NEW (not the original `id`).
+     * Callers must update any stored references.
+     *
+     * Returns the new id on success, UINT64_MAX on error. */
+    uint64_t logosdb_update(logosdb_t* db,
+                            uint64_t id,
+                            const float* embedding,
+                            int dim,
+                            const char* text,
+                            const char* timestamp,
+                            char** errptr);
 
-/* ── Search ────────────────────────────────────────────────────────── */
+    /* ── Search ────────────────────────────────────────────────────────── */
 
-logosdb_search_result_t * logosdb_search(logosdb_t * db,
-                                         const float * query, int dim,
-                                         int top_k,
-                                         char ** errptr);
+    logosdb_search_result_t*
+    logosdb_search(logosdb_t* db, const float* query, int dim, int top_k, char** errptr);
 
-/* Search with timestamp range filter.
- *   ts_from_iso8601: optional start timestamp (inclusive), NULL for no lower bound
- *   ts_to_iso8601:   optional end timestamp (inclusive), NULL for no upper bound
- *   candidate_k:     internal multiplier for post-filtering (e.g., 10x top_k)
- *
- * Returns top_k results that match both the vector similarity and timestamp range.
- * Uses post-filtering: fetches candidate_k results internally, filters by timestamp,
- * then returns the top_k that pass. Higher candidate_k improves recall but costs more.
- *
- * Timestamp format: ISO 8601 strings (e.g., "2025-01-01T00:00:00Z").
- * Comparison is lexicographic (string compare), which works correctly for ISO 8601.
- */
-logosdb_search_result_t * logosdb_search_ts_range(logosdb_t * db,
-                                                 const float * query, int dim,
-                                                 int top_k,
-                                                 const char * ts_from_iso8601,
-                                                 const char * ts_to_iso8601,
-                                                 int candidate_k,
-                                                 char ** errptr);
+    /* Search with timestamp range filter.
+     *   ts_from_iso8601: optional start timestamp (inclusive), NULL for no lower bound
+     *   ts_to_iso8601:   optional end timestamp (inclusive), NULL for no upper bound
+     *   candidate_k:     internal multiplier for post-filtering (e.g., 10x top_k)
+     *
+     * Returns top_k results that match both the vector similarity and timestamp range.
+     * Uses post-filtering: fetches candidate_k results internally, filters by timestamp,
+     * then returns the top_k that pass. Higher candidate_k improves recall but costs more.
+     *
+     * Timestamp format: ISO 8601 strings (e.g., "2025-01-01T00:00:00Z").
+     * Comparison is lexicographic (string compare), which works correctly for ISO 8601.
+     */
+    logosdb_search_result_t* logosdb_search_ts_range(logosdb_t* db,
+                                                     const float* query,
+                                                     int dim,
+                                                     int top_k,
+                                                     const char* ts_from_iso8601,
+                                                     const char* ts_to_iso8601,
+                                                     int candidate_k,
+                                                     char** errptr);
 
-int         logosdb_result_count    (const logosdb_search_result_t * r);
-uint64_t    logosdb_result_id       (const logosdb_search_result_t * r, int i);
-float       logosdb_result_score    (const logosdb_search_result_t * r, int i);
-const char* logosdb_result_text     (const logosdb_search_result_t * r, int i);
-const char* logosdb_result_timestamp(const logosdb_search_result_t * r, int i);
-void        logosdb_result_free     (logosdb_search_result_t * r);
+    int logosdb_result_count(const logosdb_search_result_t* r);
+    uint64_t logosdb_result_id(const logosdb_search_result_t* r, int i);
+    float logosdb_result_score(const logosdb_search_result_t* r, int i);
+    const char* logosdb_result_text(const logosdb_search_result_t* r, int i);
+    const char* logosdb_result_timestamp(const logosdb_search_result_t* r, int i);
+    void logosdb_result_free(logosdb_search_result_t* r);
 
-/* ── Info ──────────────────────────────────────────────────────────── */
+    /* ── Info ──────────────────────────────────────────────────────────── */
 
-/* Total row count, including rows that have been marked deleted. */
-size_t logosdb_count     (logosdb_t * db);
+    /* Total row count, including rows that have been marked deleted. */
+    size_t logosdb_count(logosdb_t* db);
 
-/* Live row count: total rows minus rows marked deleted. */
-size_t logosdb_count_live(logosdb_t * db);
+    /* Live row count: total rows minus rows marked deleted. */
+    size_t logosdb_count_live(logosdb_t* db);
 
-int    logosdb_dim       (logosdb_t * db);
+    int logosdb_dim(logosdb_t* db);
 
-/* ── Bulk read (for tensor construction) ───────────────────────────── */
+    /* ── Bulk read (for tensor construction) ───────────────────────────── */
 
-const float * logosdb_raw_vectors(logosdb_t * db, size_t * n_rows, int * dim);
+    const float* logosdb_raw_vectors(logosdb_t* db, size_t* n_rows, int* dim);
 
-/* ── Vector utilities ──────────────────────────────────────────────── */
+    /* ── Vector utilities ──────────────────────────────────────────────── */
 
-/* Normalize `vec` in-place using L2 (Euclidean) norm.
- *   vec: pointer to float array (will be modified in place)
- *   dim: number of elements in vec
- *
- * Returns 0 on success, -1 if the input has zero norm (cannot normalize).
- * On zero norm, vec is left unchanged.
- *
- * Example:
- *   float vec[128] = { ... };
- *   if (logosdb_l2_normalize(vec, 128) == 0) {
- *       logosdb_put(db, vec, 128, "text", NULL, &err);
- *   }
- */
-int logosdb_l2_normalize(float * vec, int dim);
+    /* Normalize `vec` in-place using L2 (Euclidean) norm.
+     *   vec: pointer to float array (will be modified in place)
+     *   dim: number of elements in vec
+     *
+     * Returns 0 on success, -1 if the input has zero norm (cannot normalize).
+     * On zero norm, vec is left unchanged.
+     *
+     * Example:
+     *   float vec[128] = { ... };
+     *   if (logosdb_l2_normalize(vec, 128) == 0) {
+     *       logosdb_put(db, vec, 128, "text", NULL, &err);
+     *   }
+     */
+    int logosdb_l2_normalize(float* vec, int dim);
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -187,70 +191,100 @@ int logosdb_l2_normalize(float * vec, int dim);
 /* ── C++ convenience wrapper ───────────────────────────────────────── */
 
 #ifdef __cplusplus
+#include <cstring>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <stdexcept>
-#include <cstring>
 
-namespace logosdb {
+namespace logosdb
+{
 
-struct Options {
-    int    dim              = 0;
-    size_t max_elements     = 1000000;
-    int    ef_construction  = 200;
-    int    M               = 16;
-    int    ef_search        = 50;
-    int    distance         = LOGOSDB_DIST_IP;  /* IP, COSINE, or L2 */
-    int    dtype            = LOGOSDB_DTYPE_FLOAT32;  /* FLOAT32, FLOAT16, or INT8 */
+struct Options
+{
+    int dim = 0;
+    size_t max_elements = 1000000;
+    int ef_construction = 200;
+    int M = 16;
+    int ef_search = 50;
+    int distance = LOGOSDB_DIST_IP;    /* IP, COSINE, or L2 */
+    int dtype = LOGOSDB_DTYPE_FLOAT32; /* FLOAT32, FLOAT16, or INT8 */
 };
 
-struct SearchHit {
-    uint64_t    id;
-    float       score;
+struct SearchHit
+{
+    uint64_t id;
+    float score;
     std::string text;
     std::string timestamp;
 };
 
-class DB {
-public:
-    explicit DB(const std::string & path, const Options & opts = {}) {
-        logosdb_options_t * o = logosdb_options_create();
-        if (opts.dim > 0)              logosdb_options_set_dim(o, opts.dim);
-        if (opts.max_elements > 0)     logosdb_options_set_max_elements(o, opts.max_elements);
-        if (opts.ef_construction > 0)  logosdb_options_set_ef_construction(o, opts.ef_construction);
-        if (opts.M > 0)               logosdb_options_set_M(o, opts.M);
-        if (opts.ef_search > 0)        logosdb_options_set_ef_search(o, opts.ef_search);
+class DB
+{
+  public:
+    explicit DB(const std::string& path, const Options& opts = {})
+    {
+        logosdb_options_t* o = logosdb_options_create();
+        if (opts.dim > 0)
+            logosdb_options_set_dim(o, opts.dim);
+        if (opts.max_elements > 0)
+            logosdb_options_set_max_elements(o, opts.max_elements);
+        if (opts.ef_construction > 0)
+            logosdb_options_set_ef_construction(o, opts.ef_construction);
+        if (opts.M > 0)
+            logosdb_options_set_M(o, opts.M);
+        if (opts.ef_search > 0)
+            logosdb_options_set_ef_search(o, opts.ef_search);
         logosdb_options_set_distance(o, opts.distance);
         logosdb_options_set_dtype(o, opts.dtype);
-        char * err = nullptr;
+        char* err = nullptr;
         db_ = logosdb_open(path.c_str(), o, &err);
         logosdb_options_destroy(o);
-        if (err) {
+        if (err)
+        {
             std::string msg(err);
             free(err);
             throw std::runtime_error("logosdb_open: " + msg);
         }
     }
 
-    ~DB() { if (db_) logosdb_close(db_); }
+    ~DB()
+    {
+        if (db_)
+            logosdb_close(db_);
+    }
 
-    DB(const DB &) = delete;
-    DB & operator=(const DB &) = delete;
-    DB(DB && o) noexcept : db_(o.db_) { o.db_ = nullptr; }
-    DB & operator=(DB && o) noexcept {
-        if (this != &o) { if (db_) logosdb_close(db_); db_ = o.db_; o.db_ = nullptr; }
+    DB(const DB&) = delete;
+    DB& operator=(const DB&) = delete;
+    DB(DB&& o) noexcept
+        : db_(o.db_)
+    {
+        o.db_ = nullptr;
+    }
+    DB& operator=(DB&& o) noexcept
+    {
+        if (this != &o)
+        {
+            if (db_)
+                logosdb_close(db_);
+            db_ = o.db_;
+            o.db_ = nullptr;
+        }
         return *this;
     }
 
-    uint64_t put(const std::vector<float> & embedding,
-                 const std::string & text = {},
-                 const std::string & timestamp = {}) {
-        char * err = nullptr;
-        uint64_t id = logosdb_put(db_, embedding.data(), (int)embedding.size(),
+    uint64_t put(const std::vector<float>& embedding,
+                 const std::string& text = {},
+                 const std::string& timestamp = {})
+    {
+        char* err = nullptr;
+        uint64_t id = logosdb_put(db_,
+                                  embedding.data(),
+                                  (int)embedding.size(),
                                   text.empty() ? nullptr : text.c_str(),
                                   timestamp.empty() ? nullptr : timestamp.c_str(),
                                   &err);
-        if (err) {
+        if (err)
+        {
             std::string msg(err);
             free(err);
             throw std::runtime_error("logosdb_put: " + msg);
@@ -260,34 +294,50 @@ public:
 
     /* Batch insert of n vectors. 'embeddings' must contain n*dim floats.
      * Returns vector of assigned row ids. Throws on error. */
-    std::vector<uint64_t> put_batch(const std::vector<float> & embeddings, int n,
-                                    const std::vector<std::string> & texts = {},
-                                    const std::vector<std::string> & timestamps = {}) {
-        if (n <= 0) return {};
-        if ((int)embeddings.size() < n * dim()) {
+    std::vector<uint64_t> put_batch(const std::vector<float>& embeddings,
+                                    int n,
+                                    const std::vector<std::string>& texts = {},
+                                    const std::vector<std::string>& timestamps = {})
+    {
+        if (n <= 0)
+            return {};
+        if ((int)embeddings.size() < n * dim())
+        {
             throw std::runtime_error("put_batch: embeddings size too small");
         }
         std::vector<uint64_t> ids(n);
-        std::vector<const char *> text_ptrs;
-        std::vector<const char *> ts_ptrs;
-        if (!texts.empty()) {
+        std::vector<const char*> text_ptrs;
+        std::vector<const char*> ts_ptrs;
+        if (!texts.empty())
+        {
             text_ptrs.reserve(n);
-            for (int i = 0; i < n; ++i) {
-                text_ptrs.push_back(i < (int)texts.size() && !texts[i].empty() ? texts[i].c_str() : nullptr);
+            for (int i = 0; i < n; ++i)
+            {
+                text_ptrs.push_back(i < (int)texts.size() && !texts[i].empty() ? texts[i].c_str()
+                                                                               : nullptr);
             }
         }
-        if (!timestamps.empty()) {
+        if (!timestamps.empty())
+        {
             ts_ptrs.reserve(n);
-            for (int i = 0; i < n; ++i) {
-                ts_ptrs.push_back(i < (int)timestamps.size() && !timestamps[i].empty() ? timestamps[i].c_str() : nullptr);
+            for (int i = 0; i < n; ++i)
+            {
+                ts_ptrs.push_back(i < (int)timestamps.size() && !timestamps[i].empty()
+                                      ? timestamps[i].c_str()
+                                      : nullptr);
             }
         }
-        char * err = nullptr;
-        int rc = logosdb_put_batch(db_, embeddings.data(), n, dim(),
+        char* err = nullptr;
+        int rc = logosdb_put_batch(db_,
+                                   embeddings.data(),
+                                   n,
+                                   dim(),
                                    texts.empty() ? nullptr : text_ptrs.data(),
                                    timestamps.empty() ? nullptr : ts_ptrs.data(),
-                                   ids.data(), &err);
-        if (rc != 0) {
+                                   ids.data(),
+                                   &err);
+        if (rc != 0)
+        {
             std::string msg = err ? err : "unknown";
             free(err);
             throw std::runtime_error("logosdb_put_batch: " + msg);
@@ -295,10 +345,12 @@ public:
         return ids;
     }
 
-    void del(uint64_t id) {
-        char * err = nullptr;
+    void del(uint64_t id)
+    {
+        char* err = nullptr;
         int rc = logosdb_delete(db_, id, &err);
-        if (rc != 0) {
+        if (rc != 0)
+        {
             std::string msg = err ? err : "unknown";
             free(err);
             throw std::runtime_error("logosdb_delete: " + msg);
@@ -306,16 +358,20 @@ public:
     }
 
     uint64_t update(uint64_t id,
-                    const std::vector<float> & embedding,
-                    const std::string & text = {},
-                    const std::string & timestamp = {}) {
-        char * err = nullptr;
-        uint64_t new_id = logosdb_update(db_, id,
-                                         embedding.data(), (int)embedding.size(),
+                    const std::vector<float>& embedding,
+                    const std::string& text = {},
+                    const std::string& timestamp = {})
+    {
+        char* err = nullptr;
+        uint64_t new_id = logosdb_update(db_,
+                                         id,
+                                         embedding.data(),
+                                         (int)embedding.size(),
                                          text.empty() ? nullptr : text.c_str(),
                                          timestamp.empty() ? nullptr : timestamp.c_str(),
                                          &err);
-        if (err) {
+        if (err)
+        {
             std::string msg(err);
             free(err);
             throw std::runtime_error("logosdb_update: " + msg);
@@ -323,12 +379,13 @@ public:
         return new_id;
     }
 
-    std::vector<SearchHit> search(const std::vector<float> & query, int top_k) {
-        char * err = nullptr;
-        logosdb_search_result_t * r = logosdb_search(db_, query.data(),
-                                                      (int)query.size(),
-                                                      top_k, &err);
-        if (err) {
+    std::vector<SearchHit> search(const std::vector<float>& query, int top_k)
+    {
+        char* err = nullptr;
+        logosdb_search_result_t* r =
+            logosdb_search(db_, query.data(), (int)query.size(), top_k, &err);
+        if (err)
+        {
             std::string msg(err);
             free(err);
             throw std::runtime_error("logosdb_search: " + msg);
@@ -336,14 +393,17 @@ public:
         std::vector<SearchHit> hits;
         int n = logosdb_result_count(r);
         hits.reserve(n);
-        for (int i = 0; i < n; ++i) {
+        for (int i = 0; i < n; ++i)
+        {
             SearchHit h;
-            h.id    = logosdb_result_id(r, i);
+            h.id = logosdb_result_id(r, i);
             h.score = logosdb_result_score(r, i);
-            const char * t = logosdb_result_text(r, i);
-            if (t) h.text = t;
-            const char * ts = logosdb_result_timestamp(r, i);
-            if (ts) h.timestamp = ts;
+            const char* t = logosdb_result_text(r, i);
+            if (t)
+                h.text = t;
+            const char* ts = logosdb_result_timestamp(r, i);
+            if (ts)
+                h.timestamp = ts;
             hits.push_back(std::move(h));
         }
         logosdb_result_free(r);
@@ -357,19 +417,25 @@ public:
      *
      * Timestamp format: ISO 8601 strings (e.g., "2025-01-01T00:00:00Z").
      */
-    std::vector<SearchHit> search_ts_range(const std::vector<float> & query,
-                                              int top_k,
-                                              const std::string & ts_from,
-                                              const std::string & ts_to,
-                                              int candidate_k = 0) {
-        char * err = nullptr;
+    std::vector<SearchHit> search_ts_range(const std::vector<float>& query,
+                                           int top_k,
+                                           const std::string& ts_from,
+                                           const std::string& ts_to,
+                                           int candidate_k = 0)
+    {
+        char* err = nullptr;
         int ck = candidate_k > 0 ? candidate_k : top_k * 10;
-        logosdb_search_result_t * r = logosdb_search_ts_range(
-            db_, query.data(), (int)query.size(), top_k,
-            ts_from.empty() ? nullptr : ts_from.c_str(),
-            ts_to.empty() ? nullptr : ts_to.c_str(),
-            ck, &err);
-        if (err) {
+        logosdb_search_result_t* r =
+            logosdb_search_ts_range(db_,
+                                    query.data(),
+                                    (int)query.size(),
+                                    top_k,
+                                    ts_from.empty() ? nullptr : ts_from.c_str(),
+                                    ts_to.empty() ? nullptr : ts_to.c_str(),
+                                    ck,
+                                    &err);
+        if (err)
+        {
             std::string msg(err);
             free(err);
             throw std::runtime_error("logosdb_search_ts_range: " + msg);
@@ -377,36 +443,42 @@ public:
         std::vector<SearchHit> hits;
         int n = logosdb_result_count(r);
         hits.reserve(n);
-        for (int i = 0; i < n; ++i) {
+        for (int i = 0; i < n; ++i)
+        {
             SearchHit h;
-            h.id    = logosdb_result_id(r, i);
+            h.id = logosdb_result_id(r, i);
             h.score = logosdb_result_score(r, i);
-            const char * t = logosdb_result_text(r, i);
-            if (t) h.text = t;
-            const char * ts = logosdb_result_timestamp(r, i);
-            if (ts) h.timestamp = ts;
+            const char* t = logosdb_result_text(r, i);
+            if (t)
+                h.text = t;
+            const char* ts = logosdb_result_timestamp(r, i);
+            if (ts)
+                h.timestamp = ts;
             hits.push_back(std::move(h));
         }
         logosdb_result_free(r);
         return hits;
     }
 
-    size_t count()      const { return logosdb_count(db_); }
+    size_t count() const { return logosdb_count(db_); }
     size_t count_live() const { return logosdb_count_live(db_); }
-    int    dim()        const { return logosdb_dim(db_); }
+    int dim() const { return logosdb_dim(db_); }
 
     // Get raw vectors as float32. For quantized storage, this allocates and dequantizes.
     // The caller receives a vector they own (copy for quantized, view for float32).
-    std::vector<float> raw_vectors(size_t & n_rows, int & d) const {
-        const float * raw = logosdb_raw_vectors(db_, &n_rows, &d);
-        if (raw) {
+    std::vector<float> raw_vectors(size_t& n_rows, int& d) const
+    {
+        const float* raw = logosdb_raw_vectors(db_, &n_rows, &d);
+        if (raw)
+        {
             // Float32 storage - return a copy for API consistency
             return std::vector<float>(raw, raw + n_rows * d);
         }
         // Quantized storage - need to dequantize
         n_rows = count();
         d = dim();
-        if (n_rows == 0 || d == 0) return {};
+        if (n_rows == 0 || d == 0)
+            return {};
 
         std::vector<float> result(n_rows * d);
         // Note: This is a simplified version - actual implementation would
@@ -415,13 +487,13 @@ public:
         return result;
     }
 
-    logosdb_t * handle() { return db_; }
+    logosdb_t* handle() { return db_; }
 
-private:
-    logosdb_t * db_ = nullptr;
+  private:
+    logosdb_t* db_ = nullptr;
 };
 
-} // namespace logosdb
+}  // namespace logosdb
 
 /* L2-normalization helpers for C++
  *
@@ -438,20 +510,21 @@ private:
  *   auto normalized = logosdb::l2_normalized(vec);
  *   db.put(normalized, "text");
  */
-namespace logosdb {
+namespace logosdb
+{
 
 /* Normalize `v` in-place using L2 norm.
  * Returns true on success, false if the vector has zero norm.
  * On zero norm, v is left unchanged. */
-bool l2_normalize(std::vector<float> & v);
+bool l2_normalize(std::vector<float>& v);
 
 /* Return an L2-normalized copy of `v`.
  * The input `v` is not modified.
  * Returns a zero vector if input has zero norm (caller should check). */
 std::vector<float> l2_normalized(std::vector<float> v);
 
-} // namespace logosdb
+}  // namespace logosdb
 
 #endif
 
-#endif // LOGOSDB_H
+#endif  // LOGOSDB_H

--- a/src/hnsw_index.cpp
+++ b/src/hnsw_index.cpp
@@ -1,21 +1,26 @@
 #include "hnsw_index.h"
 
 #include <hnswlib/hnswlib/hnswlib.h>
-#include <fstream>
-#include <cstring>
 
-namespace logosdb {
-namespace internal {
+#include <cstring>
+#include <fstream>
+
+namespace logosdb
+{
+namespace internal
+{
 
 /* Index file header for distance metric persistence */
-struct IndexHeader {
-    char     magic[8];        /* "LOGOSDB\0" */
-    uint32_t version;         /* 1 */
-    int32_t  distance;      /* DistanceMetric value */
-    int32_t  dim;           /* vector dimension */
-    uint8_t  reserved[12];  /* padding to 32 bytes */
+struct IndexHeader
+{
+    char magic[8];        /* "LOGOSDB\0" */
+    uint32_t version;     /* 1 */
+    int32_t distance;     /* DistanceMetric value */
+    int32_t dim;          /* vector dimension */
+    uint8_t reserved[12]; /* padding to 32 bytes */
 
-    IndexHeader() {
+    IndexHeader()
+    {
         std::memset(this, 0, sizeof(*this));
         std::memcpy(magic, "LOGOSDB\0", 8);
         version = 1;
@@ -24,38 +29,46 @@ struct IndexHeader {
     }
 };
 
-struct HnswIndex::Impl {
-    hnswlib::SpaceInterface<float> * space = nullptr;
-    hnswlib::HierarchicalNSW<float> * alg = nullptr;
+struct HnswIndex::Impl
+{
+    hnswlib::SpaceInterface<float>* space = nullptr;
+    hnswlib::HierarchicalNSW<float>* alg = nullptr;
     HnswParams params;
     DistanceMetric distance_metric = DIST_IP;
 
-    ~Impl() {
+    ~Impl()
+    {
         delete alg;
         delete space;
     }
 };
 
-HnswIndex::~HnswIndex() { close(); }
+HnswIndex::~HnswIndex()
+{
+    close();
+}
 
-static hnswlib::SpaceInterface<float> * create_space(DistanceMetric dist, int dim) {
-    switch (dist) {
-        case DIST_L2:
-            return new hnswlib::L2Space(dim);
-        case DIST_IP:
-        case DIST_COSINE:
-        default:
-            return new hnswlib::InnerProductSpace(dim);
+static hnswlib::SpaceInterface<float>* create_space(DistanceMetric dist, int dim)
+{
+    switch (dist)
+    {
+    case DIST_L2:
+        return new hnswlib::L2Space(dim);
+    case DIST_IP:
+    case DIST_COSINE:
+    default:
+        return new hnswlib::InnerProductSpace(dim);
     }
 }
 
 /* Get the metadata path from the index path */
-static std::string get_meta_path(const std::string & index_path) {
+static std::string get_meta_path(const std::string& index_path)
+{
     return index_path + ".meta";
 }
 
-bool HnswIndex::open(const std::string & path, const HnswParams & params,
-                      std::string & err) {
+bool HnswIndex::open(const std::string& path, const HnswParams& params, std::string& err)
+{
     close();
     path_ = path;
 
@@ -66,22 +79,26 @@ bool HnswIndex::open(const std::string & path, const HnswParams & params,
     // Check for metadata file with stored distance metric
     std::string meta_path = get_meta_path(path);
     std::ifstream meta_in(meta_path, std::ios::binary);
-    if (meta_in.good()) {
+    if (meta_in.good())
+    {
         IndexHeader header;
         meta_in.read(reinterpret_cast<char*>(&header), sizeof(header));
         meta_in.close();
 
-        if (std::memcmp(header.magic, "LOGOSDB\0", 8) == 0 && header.version == 1) {
+        if (std::memcmp(header.magic, "LOGOSDB\0", 8) == 0 && header.version == 1)
+        {
             // Check distance metric compatibility
             DistanceMetric stored_dist = static_cast<DistanceMetric>(header.distance);
-            if (stored_dist != impl_->distance_metric) {
+            if (stored_dist != impl_->distance_metric)
+            {
                 err = "distance metric mismatch: stored=" + std::to_string(header.distance) +
                       ", requested=" + std::to_string(params.distance);
                 close();
                 return false;
             }
             // Check dimension
-            if (header.dim != params.dim) {
+            if (header.dim != params.dim)
+            {
                 err = "dimension mismatch: stored=" + std::to_string(header.dim) +
                       ", requested=" + std::to_string(params.dim);
                 close();
@@ -92,15 +109,19 @@ bool HnswIndex::open(const std::string & path, const HnswParams & params,
 
     // Try loading existing index.
     std::ifstream in(path, std::ios::binary);
-    if (in.good() && in.peek() != std::ifstream::traits_type::eof()) {
+    if (in.good() && in.peek() != std::ifstream::traits_type::eof())
+    {
         in.close();
-        try {
+        try
+        {
             impl_->space = create_space(impl_->distance_metric, params.dim);
             impl_->alg = new hnswlib::HierarchicalNSW<float>(
                 impl_->space, path, false, params.max_elements, true);
             impl_->alg->setEf(params.ef_search);
             return true;
-        } catch (const std::exception & e) {
+        }
+        catch (const std::exception& e)
+        {
             err = std::string("hnsw load: ") + e.what();
             close();
             return false;
@@ -109,12 +130,15 @@ bool HnswIndex::open(const std::string & path, const HnswParams & params,
     in.close();
 
     // Create new index
-    try {
+    try
+    {
         impl_->space = create_space(impl_->distance_metric, params.dim);
         impl_->alg = new hnswlib::HierarchicalNSW<float>(
             impl_->space, params.max_elements, params.M, params.ef_construction);
         impl_->alg->setEf(params.ef_search);
-    } catch (const std::exception & e) {
+    }
+    catch (const std::exception& e)
+    {
         err = std::string("hnsw init: ") + e.what();
         close();
         return false;
@@ -122,101 +146,143 @@ bool HnswIndex::open(const std::string & path, const HnswParams & params,
     return true;
 }
 
-void HnswIndex::close() {
+void HnswIndex::close()
+{
     delete impl_;
     impl_ = nullptr;
     path_.clear();
 }
 
 /* Normalize a vector to unit length (for cosine similarity) */
-static void l2_normalize(float * vec, int dim) {
+static void l2_normalize(float* vec, int dim)
+{
     float norm = 0.0f;
-    for (int i = 0; i < dim; ++i) {
+    for (int i = 0; i < dim; ++i)
+    {
         norm += vec[i] * vec[i];
     }
     norm = std::sqrt(norm);
-    if (norm > 0.0f) {
-        for (int i = 0; i < dim; ++i) {
+    if (norm > 0.0f)
+    {
+        for (int i = 0; i < dim; ++i)
+        {
             vec[i] /= norm;
         }
     }
 }
 
-bool HnswIndex::add(uint64_t label, const float * vec, std::string & err) {
-    if (!impl_ || !impl_->alg) { err = "index not open"; return false; }
-    try {
-        if (impl_->distance_metric == DIST_COSINE) {
+bool HnswIndex::add(uint64_t label, const float* vec, std::string& err)
+{
+    if (!impl_ || !impl_->alg)
+    {
+        err = "index not open";
+        return false;
+    }
+    try
+    {
+        if (impl_->distance_metric == DIST_COSINE)
+        {
             // Make a copy and normalize for cosine similarity
             std::vector<float> normalized(vec, vec + impl_->params.dim);
             l2_normalize(normalized.data(), impl_->params.dim);
             impl_->alg->addPoint(normalized.data(), (hnswlib::labeltype)label);
-        } else {
+        }
+        else
+        {
             impl_->alg->addPoint(vec, (hnswlib::labeltype)label);
         }
-    } catch (const std::exception & e) {
+    }
+    catch (const std::exception& e)
+    {
         err = std::string("hnsw add: ") + e.what();
         return false;
     }
     return true;
 }
 
-bool HnswIndex::mark_deleted(uint64_t label, std::string & err) {
-    if (!impl_ || !impl_->alg) { err = "index not open"; return false; }
-    try {
+bool HnswIndex::mark_deleted(uint64_t label, std::string& err)
+{
+    if (!impl_ || !impl_->alg)
+    {
+        err = "index not open";
+        return false;
+    }
+    try
+    {
         impl_->alg->markDelete((hnswlib::labeltype)label);
-    } catch (const std::exception & e) {
+    }
+    catch (const std::exception& e)
+    {
         err = std::string("hnsw markDelete: ") + e.what();
         return false;
     }
     return true;
 }
 
-bool HnswIndex::is_deleted(uint64_t label) const {
-    if (!impl_ || !impl_->alg) return false;
-    auto & lookup = impl_->alg->label_lookup_;
+bool HnswIndex::is_deleted(uint64_t label) const
+{
+    if (!impl_ || !impl_->alg)
+        return false;
+    auto& lookup = impl_->alg->label_lookup_;
     std::unique_lock<std::mutex> lk(impl_->alg->label_lookup_lock);
     auto it = lookup.find((hnswlib::labeltype)label);
-    if (it == lookup.end()) return false;
+    if (it == lookup.end())
+        return false;
     auto internal_id = it->second;
     lk.unlock();
     return impl_->alg->isMarkedDeleted(internal_id);
 }
 
-bool HnswIndex::has_label(uint64_t label) const {
-    if (!impl_ || !impl_->alg) return false;
-    auto & lookup = impl_->alg->label_lookup_;
+bool HnswIndex::has_label(uint64_t label) const
+{
+    if (!impl_ || !impl_->alg)
+        return false;
+    auto& lookup = impl_->alg->label_lookup_;
     std::unique_lock<std::mutex> lk(impl_->alg->label_lookup_lock);
     return lookup.find((hnswlib::labeltype)label) != lookup.end();
 }
 
 std::vector<std::pair<uint64_t, float>>
-HnswIndex::search(const float * query, int top_k, std::string & err) const {
+HnswIndex::search(const float* query, int top_k, std::string& err) const
+{
     std::vector<std::pair<uint64_t, float>> results;
-    if (!impl_ || !impl_->alg) { err = "index not open"; return results; }
-    if (impl_->alg->cur_element_count == 0) return results;
-    if (top_k <= 0) return results;
+    if (!impl_ || !impl_->alg)
+    {
+        err = "index not open";
+        return results;
+    }
+    if (impl_->alg->cur_element_count == 0)
+        return results;
+    if (top_k <= 0)
+        return results;
 
     size_t k = std::min((size_t)top_k, (size_t)impl_->alg->cur_element_count);
 
     // Prepare query (normalize for cosine)
     std::vector<float> normalized_query;
-    const float * search_vec = query;
-    if (impl_->distance_metric == DIST_COSINE) {
+    const float* search_vec = query;
+    if (impl_->distance_metric == DIST_COSINE)
+    {
         normalized_query.assign(query, query + impl_->params.dim);
         l2_normalize(normalized_query.data(), impl_->params.dim);
         search_vec = normalized_query.data();
     }
 
-    try {
+    try
+    {
         auto pq = impl_->alg->searchKnn(search_vec, k);
         results.reserve(pq.size());
-        while (!pq.empty()) {
-            auto & top = pq.top();
+        while (!pq.empty())
+        {
+            auto& top = pq.top();
             float score;
-            if (impl_->distance_metric == DIST_L2) {
+            if (impl_->distance_metric == DIST_L2)
+            {
                 // L2: distance is already correct, invert so higher = more similar
                 score = 1.0f / (1.0f + top.first);
-            } else {
+            }
+            else
+            {
                 // IP/Cosine: hnswlib returns (1 - ip) as distance; convert back
                 score = 1.0f - top.first;
             }
@@ -225,26 +291,37 @@ HnswIndex::search(const float * query, int top_k, std::string & err) const {
         }
         // Reverse so highest score is first.
         std::reverse(results.begin(), results.end());
-    } catch (const std::exception & e) {
+    }
+    catch (const std::exception& e)
+    {
         err = std::string("hnsw search: ") + e.what();
     }
     return results;
 }
 
-size_t HnswIndex::count() const {
-    if (!impl_ || !impl_->alg) return 0;
+size_t HnswIndex::count() const
+{
+    if (!impl_ || !impl_->alg)
+        return 0;
     return impl_->alg->cur_element_count;
 }
 
-bool HnswIndex::save(std::string & err) const {
-    if (!impl_ || !impl_->alg) { err = "index not open"; return false; }
-    try {
+bool HnswIndex::save(std::string& err) const
+{
+    if (!impl_ || !impl_->alg)
+    {
+        err = "index not open";
+        return false;
+    }
+    try
+    {
         impl_->alg->saveIndex(path_);
 
         // Write metadata file with distance metric
         std::string meta_path = get_meta_path(path_);
         std::ofstream meta_out(meta_path, std::ios::binary | std::ios::trunc);
-        if (!meta_out.good()) {
+        if (!meta_out.good())
+        {
             err = "cannot write index metadata";
             return false;
         }
@@ -255,12 +332,14 @@ bool HnswIndex::save(std::string & err) const {
 
         meta_out.write(reinterpret_cast<const char*>(&header), sizeof(header));
         meta_out.close();
-    } catch (const std::exception & e) {
+    }
+    catch (const std::exception& e)
+    {
         err = std::string("hnsw save: ") + e.what();
         return false;
     }
     return true;
 }
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/src/hnsw_index.h
+++ b/src/hnsw_index.h
@@ -6,44 +6,49 @@
 #include <utility>
 #include <vector>
 
-namespace logosdb {
-namespace internal {
+namespace logosdb
+{
+namespace internal
+{
 
 /* Distance metrics - match the public API constants */
-enum DistanceMetric {
-    DIST_IP = 0,      /* Inner product */
-    DIST_COSINE = 1,  /* Cosine (IP on normalized vectors) */
-    DIST_L2 = 2       /* Euclidean distance */
+enum DistanceMetric
+{
+    DIST_IP = 0,     /* Inner product */
+    DIST_COSINE = 1, /* Cosine (IP on normalized vectors) */
+    DIST_L2 = 2      /* Euclidean distance */
 };
 
-struct HnswParams {
-    int    dim             = 0;
-    size_t max_elements    = 1000000;
-    int    ef_construction = 200;
-    int    M               = 16;
-    int    ef_search       = 50;
-    int    distance        = DIST_IP;  /* DIST_IP, DIST_COSINE, or DIST_L2 */
+struct HnswParams
+{
+    int dim = 0;
+    size_t max_elements = 1000000;
+    int ef_construction = 200;
+    int M = 16;
+    int ef_search = 50;
+    int distance = DIST_IP; /* DIST_IP, DIST_COSINE, or DIST_L2 */
 };
 
 // Thin wrapper around hnswlib for inner-product search on L2-normalized vectors.
-class HnswIndex {
-public:
+class HnswIndex
+{
+  public:
     HnswIndex() = default;
     ~HnswIndex();
 
-    HnswIndex(const HnswIndex &) = delete;
-    HnswIndex & operator=(const HnswIndex &) = delete;
+    HnswIndex(const HnswIndex&) = delete;
+    HnswIndex& operator=(const HnswIndex&) = delete;
 
     // Create a new index or load an existing one from disk.
-    bool open(const std::string & path, const HnswParams & params, std::string & err);
+    bool open(const std::string& path, const HnswParams& params, std::string& err);
     void close();
 
     // Add a vector with the given internal label (row index).
-    bool add(uint64_t label, const float * vec, std::string & err);
+    bool add(uint64_t label, const float* vec, std::string& err);
 
     // Mark `label` as deleted. Excluded from subsequent search results.
     // Returns false if the label is not in the index.
-    bool mark_deleted(uint64_t label, std::string & err);
+    bool mark_deleted(uint64_t label, std::string& err);
 
     // True if `label` exists in the index and is currently marked deleted.
     // Returns false if the label is missing.
@@ -56,17 +61,17 @@ public:
     // Search for top-k nearest. Returns (label, distance) pairs sorted by distance desc
     // (inner product — higher is more similar).
     std::vector<std::pair<uint64_t, float>>
-    search(const float * query, int top_k, std::string & err) const;
+    search(const float* query, int top_k, std::string& err) const;
 
     size_t count() const;
 
-    bool save(std::string & err) const;
+    bool save(std::string& err) const;
 
-private:
+  private:
     struct Impl;
-    Impl * impl_ = nullptr;
+    Impl* impl_ = nullptr;
     std::string path_;
 };
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/src/logosdb.cpp
+++ b/src/logosdb.cpp
@@ -1,9 +1,10 @@
-#include <logosdb/logosdb.h>
+#include "hnsw_index.h"
+#include "metadata.h"
 #include "platform.h"
 #include "storage.h"
-#include "metadata.h"
-#include "hnsw_index.h"
 #include "wal.h"
+
+#include <logosdb/logosdb.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -17,29 +18,33 @@ using namespace logosdb::internal;
 
 /* ── Internal DB struct ────────────────────────────────────────────── */
 
-struct logosdb_t {
-    VectorStorage   vectors;
-    MetadataStore   meta;
-    HnswIndex       index;
-    WriteAheadLog   wal;
-    std::mutex      mu;
-    int             dim = 0;
+struct logosdb_t
+{
+    VectorStorage vectors;
+    MetadataStore meta;
+    HnswIndex index;
+    WriteAheadLog wal;
+    std::mutex mu;
+    int dim = 0;
 };
 
-struct logosdb_options_t {
-    int    dim             = 0;
-    size_t max_elements    = 1000000;
-    int    ef_construction = 200;
-    int    M               = 16;
-    int    ef_search       = 50;
-    int    distance        = 0;  /* LOGOSDB_DIST_IP default */
-    int    dtype           = 0;  /* LOGOSDB_DTYPE_FLOAT32 default */
+struct logosdb_options_t
+{
+    int dim = 0;
+    size_t max_elements = 1000000;
+    int ef_construction = 200;
+    int M = 16;
+    int ef_search = 50;
+    int distance = 0; /* LOGOSDB_DIST_IP default */
+    int dtype = 0;    /* LOGOSDB_DTYPE_FLOAT32 default */
 };
 
-struct logosdb_search_result_t {
-    struct Hit {
-        uint64_t    id;
-        float       score;
+struct logosdb_search_result_t
+{
+    struct Hit
+    {
+        uint64_t id;
+        float score;
         std::string text;
         std::string timestamp;
     };
@@ -48,45 +53,78 @@ struct logosdb_search_result_t {
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
-static void set_err(char ** errptr, const std::string & msg) {
-    if (errptr) {
+static void set_err(char** errptr, const std::string& msg)
+{
+    if (errptr)
+    {
         *errptr = platform::string_duplicate(msg.c_str());
     }
 }
 
 /* ── Options ───────────────────────────────────────────────────────── */
 
-logosdb_options_t * logosdb_options_create(void) {
+logosdb_options_t* logosdb_options_create(void)
+{
     return new logosdb_options_t();
 }
 
-void logosdb_options_destroy(logosdb_options_t * opts) { delete opts; }
+void logosdb_options_destroy(logosdb_options_t* opts)
+{
+    delete opts;
+}
 
-void logosdb_options_set_dim(logosdb_options_t * o, int d)             { if (o && d > 0) o->dim = d; }
-void logosdb_options_set_max_elements(logosdb_options_t * o, size_t n) { if (o && n > 0) o->max_elements = n; }
-void logosdb_options_set_ef_construction(logosdb_options_t * o, int e) { if (o && e > 0) o->ef_construction = e; }
-void logosdb_options_set_M(logosdb_options_t * o, int m)              { if (o && m > 0) o->M = m; }
-void logosdb_options_set_ef_search(logosdb_options_t * o, int e)      { if (o && e > 0) o->ef_search = e; }
+void logosdb_options_set_dim(logosdb_options_t* o, int d)
+{
+    if (o && d > 0)
+        o->dim = d;
+}
+void logosdb_options_set_max_elements(logosdb_options_t* o, size_t n)
+{
+    if (o && n > 0)
+        o->max_elements = n;
+}
+void logosdb_options_set_ef_construction(logosdb_options_t* o, int e)
+{
+    if (o && e > 0)
+        o->ef_construction = e;
+}
+void logosdb_options_set_M(logosdb_options_t* o, int m)
+{
+    if (o && m > 0)
+        o->M = m;
+}
+void logosdb_options_set_ef_search(logosdb_options_t* o, int e)
+{
+    if (o && e > 0)
+        o->ef_search = e;
+}
 
-int logosdb_options_set_distance(logosdb_options_t * o, int metric) {
-    if (!o) return -1;
-    if (metric < 0 || metric > 2) return -1;  /* Invalid metric */
+int logosdb_options_set_distance(logosdb_options_t* o, int metric)
+{
+    if (!o)
+        return -1;
+    if (metric < 0 || metric > 2)
+        return -1; /* Invalid metric */
     o->distance = metric;
     return 0;
 }
 
-int logosdb_options_set_dtype(logosdb_options_t * o, int dtype) {
-    if (!o) return -1;
-    if (dtype < 0 || dtype > 2) return -1;  /* Invalid dtype */
+int logosdb_options_set_dtype(logosdb_options_t* o, int dtype)
+{
+    if (!o)
+        return -1;
+    if (dtype < 0 || dtype > 2)
+        return -1; /* Invalid dtype */
     o->dtype = dtype;
     return 0;
 }
 
 /* ── Lifecycle ─────────────────────────────────────────────────────── */
 
-logosdb_t * logosdb_open(const char * path, const logosdb_options_t * opts,
-                         char ** errptr) {
-    if (!path || !opts || opts->dim <= 0) {
+logosdb_t* logosdb_open(const char* path, const logosdb_options_t* opts, char** errptr)
+{
+    if (!path || !opts || opts->dim <= 0)
+    {
         set_err(errptr, "invalid arguments: path and dim > 0 required");
         return nullptr;
     }
@@ -97,39 +135,43 @@ logosdb_t * logosdb_open(const char * path, const logosdb_options_t * opts,
     db->dim = opts->dim;
     std::string err;
 
-    std::string vec_path  = std::string(path) + "/vectors.bin";
+    std::string vec_path = std::string(path) + "/vectors.bin";
     std::string meta_path = std::string(path) + "/meta.jsonl";
-    std::string idx_path  = std::string(path) + "/hnsw.idx";
-    std::string wal_path  = std::string(path) + "/wal.log";
+    std::string idx_path = std::string(path) + "/hnsw.idx";
+    std::string wal_path = std::string(path) + "/wal.log";
 
     StorageDtype dtype = static_cast<StorageDtype>(opts->dtype);
-    if (!db->vectors.open(vec_path, opts->dim, dtype, err)) {
+    if (!db->vectors.open(vec_path, opts->dim, dtype, err))
+    {
         set_err(errptr, err);
         delete db;
         return nullptr;
     }
-    if (!db->meta.open(meta_path, err)) {
+    if (!db->meta.open(meta_path, err))
+    {
         set_err(errptr, err);
         delete db;
         return nullptr;
     }
 
     HnswParams hp;
-    hp.dim             = opts->dim;
-    hp.max_elements    = opts->max_elements;
+    hp.dim = opts->dim;
+    hp.max_elements = opts->max_elements;
     hp.ef_construction = opts->ef_construction;
-    hp.M               = opts->M;
-    hp.ef_search       = opts->ef_search;
-    hp.distance        = opts->distance;
+    hp.M = opts->M;
+    hp.ef_search = opts->ef_search;
+    hp.distance = opts->distance;
 
-    if (!db->index.open(idx_path, hp, err)) {
+    if (!db->index.open(idx_path, hp, err))
+    {
         set_err(errptr, err);
         delete db;
         return nullptr;
     }
 
     // Open WAL and replay any pending entries for atomic recovery.
-    if (!db->wal.open(wal_path, err)) {
+    if (!db->wal.open(wal_path, err))
+    {
         set_err(errptr, err);
         delete db;
         return nullptr;
@@ -137,9 +179,11 @@ logosdb_t * logosdb_open(const char * path, const logosdb_options_t * opts,
 
     // Replay pending WAL entries to ensure consistency.
     int replayed = db->wal.replay_pending(
-        [&db](const WALEntry & entry, std::string & replay_err) -> bool {
+        [&db](const WALEntry& entry, std::string& replay_err) -> bool
+        {
             // Validate: expected_id should match current row count
-            if (entry.expected_id != db->vectors.n_rows()) {
+            if (entry.expected_id != db->vectors.n_rows())
+            {
                 replay_err = "wal replay: expected_id mismatch (" +
                              std::to_string(entry.expected_id) + " vs " +
                              std::to_string(db->vectors.n_rows()) + ")";
@@ -148,23 +192,26 @@ logosdb_t * logosdb_open(const char * path, const logosdb_options_t * opts,
 
             // Replay vector
             uint64_t vid = db->vectors.append(entry.vector.data(), (int)entry.dim, replay_err);
-            if (vid == UINT64_MAX) return false;
+            if (vid == UINT64_MAX)
+                return false;
 
             // Replay metadata
             uint64_t mid = db->meta.append(entry.text.c_str(), entry.timestamp.c_str(), replay_err);
-            if (mid == UINT64_MAX) return false;
+            if (mid == UINT64_MAX)
+                return false;
 
             // Replay index
-            if (!db->index.add(vid, entry.vector.data(), replay_err)) {
+            if (!db->index.add(vid, entry.vector.data(), replay_err))
+            {
                 return false;
             }
 
             return true;
         },
-        err
-    );
+        err);
 
-    if (replayed < 0) {
+    if (replayed < 0)
+    {
         set_err(errptr, "wal replay: " + err);
         delete db;
         return nullptr;
@@ -173,12 +220,15 @@ logosdb_t * logosdb_open(const char * path, const logosdb_options_t * opts,
     // Backfill index if vector storage has more rows than the index (e.g. crash recovery).
     size_t n_vec = db->vectors.n_rows();
     size_t n_idx = db->index.count();
-    bool   backfilled = false;
-    if (n_vec > n_idx) {
+    bool backfilled = false;
+    if (n_vec > n_idx)
+    {
         std::vector<float> float32_row(db->dim);
-        for (size_t i = n_idx; i < n_vec; ++i) {
+        for (size_t i = n_idx; i < n_vec; ++i)
+        {
             db->vectors.row_to_float32(i, float32_row.data());
-            if (!db->index.add(i, float32_row.data(), err)) {
+            if (!db->index.add(i, float32_row.data(), err))
+            {
                 set_err(errptr, "backfill index: " + err);
                 delete db;
                 return nullptr;
@@ -192,25 +242,32 @@ logosdb_t * logosdb_open(const char * path, const logosdb_options_t * opts,
     // tombstone log, we may have live slots for rows the metadata log says are
     // deleted. Replay the tombstone set onto the index (skip entries already
     // marked to tolerate normal reopens).
-    for (uint64_t id : db->meta.deleted_ids()) {
-        if (!db->index.has_label(id)) continue;
-        if (db->index.is_deleted(id)) continue;
-        if (!db->index.mark_deleted(id, err)) {
+    for (uint64_t id : db->meta.deleted_ids())
+    {
+        if (!db->index.has_label(id))
+            continue;
+        if (db->index.is_deleted(id))
+            continue;
+        if (!db->index.mark_deleted(id, err))
+        {
             set_err(errptr, "replay tombstone: " + err);
             delete db;
             return nullptr;
         }
     }
 
-    if (backfilled) db->index.save(err);
+    if (backfilled)
+        db->index.save(err);
 
     return db;
 }
 
-void logosdb_close(logosdb_t * db) {
-    if (!db) return;
+void logosdb_close(logosdb_t* db)
+{
+    if (!db)
+        return;
     std::string err;
-    db->wal.sync(err);   // Ensure WAL is durable before closing other stores
+    db->wal.sync(err);  // Ensure WAL is durable before closing other stores
     db->index.save(err);
     db->vectors.sync(err);
     db->meta.sync(err);
@@ -220,16 +277,20 @@ void logosdb_close(logosdb_t * db) {
 
 /* ── Write ─────────────────────────────────────────────────────────── */
 
-uint64_t logosdb_put(logosdb_t * db,
-                     const float * embedding, int dim,
-                     const char * text,
-                     const char * timestamp,
-                     char ** errptr) {
-    if (!db || !embedding) {
+uint64_t logosdb_put(logosdb_t* db,
+                     const float* embedding,
+                     int dim,
+                     const char* text,
+                     const char* timestamp,
+                     char** errptr)
+{
+    if (!db || !embedding)
+    {
         set_err(errptr, "null db or embedding");
         return UINT64_MAX;
     }
-    if (dim != db->dim) {
+    if (dim != db->dim)
+    {
         set_err(errptr, "dimension mismatch");
         return UINT64_MAX;
     }
@@ -242,29 +303,40 @@ uint64_t logosdb_put(logosdb_t * db,
 
     // Step 1: Write WAL entry (durability point)
     int64_t wal_offset = db->wal.append_pending(embedding, dim, text, timestamp, expected_id, err);
-    if (wal_offset < 0) { set_err(errptr, err); return UINT64_MAX; }
+    if (wal_offset < 0)
+    {
+        set_err(errptr, err);
+        return UINT64_MAX;
+    }
 
     // Step 2: Write to vector storage
     uint64_t vid = db->vectors.append(embedding, dim, err);
-    if (vid == UINT64_MAX) { set_err(errptr, err); return UINT64_MAX; }
+    if (vid == UINT64_MAX)
+    {
+        set_err(errptr, err);
+        return UINT64_MAX;
+    }
 
     // Step 3: Write to metadata storage
     uint64_t mid = db->meta.append(text, timestamp, err);
-    if (mid == UINT64_MAX) {
+    if (mid == UINT64_MAX)
+    {
         // Metadata write failed - entry remains in WAL for replay on recovery
         set_err(errptr, err);
         return UINT64_MAX;
     }
 
     // Step 4: Write to HNSW index
-    if (!db->index.add(vid, embedding, err)) {
+    if (!db->index.add(vid, embedding, err))
+    {
         // Index write failed - entry remains in WAL for replay on recovery
         set_err(errptr, err);
         return UINT64_MAX;
     }
 
     // Step 5: Mark WAL entry as committed
-    if (!db->wal.mark_committed(wal_offset, err)) {
+    if (!db->wal.mark_committed(wal_offset, err))
+    {
         // Non-fatal: entry will be replayed on next open if needed
         // Log but don't fail the operation
     }
@@ -272,20 +344,26 @@ uint64_t logosdb_put(logosdb_t * db,
     return vid;
 }
 
-int logosdb_put_batch(logosdb_t * db,
-                      const float * embeddings, int n, int dim,
-                      const char * const * texts,
-                      const char * const * timestamps,
-                      uint64_t * out_ids,
-                      char ** errptr) {
-    if (!db || !embeddings || !out_ids) {
+int logosdb_put_batch(logosdb_t* db,
+                      const float* embeddings,
+                      int n,
+                      int dim,
+                      const char* const* texts,
+                      const char* const* timestamps,
+                      uint64_t* out_ids,
+                      char** errptr)
+{
+    if (!db || !embeddings || !out_ids)
+    {
         set_err(errptr, "null db, embeddings, or out_ids");
         return -1;
     }
-    if (n <= 0) {
+    if (n <= 0)
+    {
         return 0;  // Empty batch is a no-op success
     }
-    if (dim != db->dim) {
+    if (dim != db->dim)
+    {
         set_err(errptr, "dimension mismatch");
         return -1;
     }
@@ -299,31 +377,36 @@ int logosdb_put_batch(logosdb_t * db,
 
     // Step 1: Batch write to vector storage (single ftruncate + pwrite)
     uint64_t vid = db->vectors.append_batch(embeddings, n, dim, err);
-    if (vid == UINT64_MAX) {
+    if (vid == UINT64_MAX)
+    {
         set_err(errptr, err);
         return -1;
     }
 
     // Step 2: Batch write to metadata storage
     uint64_t mid = db->meta.append_batch(texts, timestamps, n, err);
-    if (mid == UINT64_MAX) {
+    if (mid == UINT64_MAX)
+    {
         set_err(errptr, err);
         return -1;
     }
 
     // Step 3: Add to HNSW index (must be done per-vector)
-    const float * vec = embeddings;
+    const float* vec = embeddings;
     size_t stride = (size_t)dim * sizeof(float);
-    for (int i = 0; i < n; ++i) {
-        if (!db->index.add(vid + i, vec, err)) {
+    for (int i = 0; i < n; ++i)
+    {
+        if (!db->index.add(vid + i, vec, err))
+        {
             set_err(errptr, err);
             return -1;
         }
-        vec = reinterpret_cast<const float *>(reinterpret_cast<const uint8_t *>(vec) + stride);
+        vec = reinterpret_cast<const float*>(reinterpret_cast<const uint8_t*>(vec) + stride);
     }
 
     // Fill out_ids with assigned ids
-    for (int i = 0; i < n; ++i) {
+    for (int i = 0; i < n; ++i)
+    {
         out_ids[i] = vid + i;
     }
 
@@ -332,29 +415,38 @@ int logosdb_put_batch(logosdb_t * db,
 
 /* ── Delete / Update ───────────────────────────────────────────────── */
 
-int logosdb_delete(logosdb_t * db, uint64_t id, char ** errptr) {
-    if (!db) { set_err(errptr, "null db"); return -1; }
+int logosdb_delete(logosdb_t* db, uint64_t id, char** errptr)
+{
+    if (!db)
+    {
+        set_err(errptr, "null db");
+        return -1;
+    }
 
     std::lock_guard<std::mutex> lock(db->mu);
     std::string err;
 
-    if (id >= db->vectors.n_rows()) {
+    if (id >= db->vectors.n_rows())
+    {
         set_err(errptr, "delete: id out of range");
         return -1;
     }
-    if (db->meta.is_deleted(id)) {
+    if (db->meta.is_deleted(id))
+    {
         set_err(errptr, "delete: id already deleted");
         return -1;
     }
 
     // Mark in the index first. If hnswlib rejects (e.g. label missing because
     // the row was never indexed), bail out before touching the metadata log.
-    if (!db->index.mark_deleted(id, err)) {
+    if (!db->index.mark_deleted(id, err))
+    {
         set_err(errptr, err);
         return -1;
     }
 
-    if (!db->meta.mark_deleted(id, err)) {
+    if (!db->meta.mark_deleted(id, err))
+    {
         // Index is now marked but metadata failed. Best-effort rollback so
         // the two stores don't diverge.
         std::string ignore;
@@ -365,16 +457,21 @@ int logosdb_delete(logosdb_t * db, uint64_t id, char ** errptr) {
     return 0;
 }
 
-uint64_t logosdb_update(logosdb_t * db, uint64_t id,
-                        const float * embedding, int dim,
-                        const char * text,
-                        const char * timestamp,
-                        char ** errptr) {
-    if (!db || !embedding) {
+uint64_t logosdb_update(logosdb_t* db,
+                        uint64_t id,
+                        const float* embedding,
+                        int dim,
+                        const char* text,
+                        const char* timestamp,
+                        char** errptr)
+{
+    if (!db || !embedding)
+    {
         set_err(errptr, "null db or embedding");
         return UINT64_MAX;
     }
-    if (dim != db->dim) {
+    if (dim != db->dim)
+    {
         set_err(errptr, "dimension mismatch");
         return UINT64_MAX;
     }
@@ -382,33 +479,46 @@ uint64_t logosdb_update(logosdb_t * db, uint64_t id,
     std::lock_guard<std::mutex> lock(db->mu);
     std::string err;
 
-    if (id >= db->vectors.n_rows()) {
+    if (id >= db->vectors.n_rows())
+    {
         set_err(errptr, "update: id out of range");
         return UINT64_MAX;
     }
-    if (db->meta.is_deleted(id)) {
+    if (db->meta.is_deleted(id))
+    {
         set_err(errptr, "update: id already deleted");
         return UINT64_MAX;
     }
 
     // Mark the old row deleted, then append a fresh row. The two operations
     // share the write mutex, so no reader sees an intermediate state.
-    if (!db->index.mark_deleted(id, err)) {
+    if (!db->index.mark_deleted(id, err))
+    {
         set_err(errptr, err);
         return UINT64_MAX;
     }
-    if (!db->meta.mark_deleted(id, err)) {
+    if (!db->meta.mark_deleted(id, err))
+    {
         set_err(errptr, err);
         return UINT64_MAX;
     }
 
     uint64_t vid = db->vectors.append(embedding, dim, err);
-    if (vid == UINT64_MAX) { set_err(errptr, err); return UINT64_MAX; }
+    if (vid == UINT64_MAX)
+    {
+        set_err(errptr, err);
+        return UINT64_MAX;
+    }
 
     uint64_t mid = db->meta.append(text, timestamp, err);
-    if (mid == UINT64_MAX) { set_err(errptr, err); return UINT64_MAX; }
+    if (mid == UINT64_MAX)
+    {
+        set_err(errptr, err);
+        return UINT64_MAX;
+    }
 
-    if (!db->index.add(vid, embedding, err)) {
+    if (!db->index.add(vid, embedding, err))
+    {
         set_err(errptr, err);
         return UINT64_MAX;
     }
@@ -417,39 +527,44 @@ uint64_t logosdb_update(logosdb_t * db, uint64_t id,
 
 /* ── Search ────────────────────────────────────────────────────────── */
 
-logosdb_search_result_t * logosdb_search(logosdb_t * db,
-                                         const float * query, int dim,
-                                         int top_k,
-                                         char ** errptr) {
-    if (!db || !query) {
+logosdb_search_result_t*
+logosdb_search(logosdb_t* db, const float* query, int dim, int top_k, char** errptr)
+{
+    if (!db || !query)
+    {
         set_err(errptr, "null db or query");
         return nullptr;
     }
-    if (dim != db->dim) {
+    if (dim != db->dim)
+    {
         set_err(errptr, "dimension mismatch in search");
         return nullptr;
     }
-    if (top_k <= 0) {
+    if (top_k <= 0)
+    {
         set_err(errptr, "top_k must be > 0");
         return nullptr;
     }
 
     std::string err;
     auto raw = db->index.search(query, top_k, err);
-    if (!err.empty()) {
+    if (!err.empty())
+    {
         set_err(errptr, err);
         return nullptr;
     }
 
-    auto * r = new logosdb_search_result_t();
+    auto* r = new logosdb_search_result_t();
     r->hits.reserve(raw.size());
-    for (auto & [label, score] : raw) {
+    for (auto& [label, score] : raw)
+    {
         logosdb_search_result_t::Hit h;
-        h.id    = label;
+        h.id = label;
         h.score = score;
-        auto * m = db->meta.row(label);
-        if (m) {
-            h.text      = m->text;
+        auto* m = db->meta.row(label);
+        if (m)
+        {
+            h.text = m->text;
             h.timestamp = m->timestamp;
         }
         r->hits.push_back(std::move(h));
@@ -457,61 +572,75 @@ logosdb_search_result_t * logosdb_search(logosdb_t * db,
     return r;
 }
 
-logosdb_search_result_t * logosdb_search_ts_range(logosdb_t * db,
-                                                 const float * query, int dim,
+logosdb_search_result_t* logosdb_search_ts_range(logosdb_t* db,
+                                                 const float* query,
+                                                 int dim,
                                                  int top_k,
-                                                 const char * ts_from_iso8601,
-                                                 const char * ts_to_iso8601,
+                                                 const char* ts_from_iso8601,
+                                                 const char* ts_to_iso8601,
                                                  int candidate_k,
-                                                 char ** errptr) {
-    if (!db || !query) {
+                                                 char** errptr)
+{
+    if (!db || !query)
+    {
         set_err(errptr, "null db or query");
         return nullptr;
     }
-    if (dim != db->dim) {
+    if (dim != db->dim)
+    {
         set_err(errptr, "dimension mismatch in search");
         return nullptr;
     }
-    if (top_k <= 0) {
+    if (top_k <= 0)
+    {
         set_err(errptr, "top_k must be > 0");
         return nullptr;
     }
-    if (candidate_k < top_k) {
+    if (candidate_k < top_k)
+    {
         candidate_k = top_k;  // Ensure we fetch at least top_k candidates
     }
 
     std::string err;
     // Fetch more candidates than needed to allow for filtering
     auto raw = db->index.search(query, candidate_k, err);
-    if (!err.empty()) {
+    if (!err.empty())
+    {
         set_err(errptr, err);
         return nullptr;
     }
 
-    auto * r = new logosdb_search_result_t();
+    auto* r = new logosdb_search_result_t();
     r->hits.reserve(top_k);
 
-    for (auto & [label, score] : raw) {
+    for (auto& [label, score] : raw)
+    {
         // Check if we've collected enough results
-        if ((int)r->hits.size() >= top_k) break;
+        if ((int)r->hits.size() >= top_k)
+            break;
 
         // Get metadata for this row
-        auto * m = db->meta.row(label);
-        if (!m) continue;
+        auto* m = db->meta.row(label);
+        if (!m)
+            continue;
 
         // Apply timestamp filter
-        if (ts_from_iso8601 && !m->timestamp.empty()) {
-            if (m->timestamp < ts_from_iso8601) continue;  // Before start
+        if (ts_from_iso8601 && !m->timestamp.empty())
+        {
+            if (m->timestamp < ts_from_iso8601)
+                continue;  // Before start
         }
-        if (ts_to_iso8601 && !m->timestamp.empty()) {
-            if (m->timestamp > ts_to_iso8601) continue;  // After end
+        if (ts_to_iso8601 && !m->timestamp.empty())
+        {
+            if (m->timestamp > ts_to_iso8601)
+                continue;  // After end
         }
 
         // This result passes the filter
         logosdb_search_result_t::Hit h;
-        h.id    = label;
+        h.id = label;
         h.score = score;
-        h.text  = m->text;
+        h.text = m->text;
         h.timestamp = m->timestamp;
         r->hits.push_back(std::move(h));
     }
@@ -519,98 +648,134 @@ logosdb_search_result_t * logosdb_search_ts_range(logosdb_t * db,
     return r;
 }
 
-int logosdb_result_count(const logosdb_search_result_t * r) {
+int logosdb_result_count(const logosdb_search_result_t* r)
+{
     return r ? (int)r->hits.size() : 0;
 }
 
-uint64_t logosdb_result_id(const logosdb_search_result_t * r, int i) {
+uint64_t logosdb_result_id(const logosdb_search_result_t* r, int i)
+{
     return (r && i >= 0 && i < (int)r->hits.size()) ? r->hits[i].id : UINT64_MAX;
 }
 
-float logosdb_result_score(const logosdb_search_result_t * r, int i) {
+float logosdb_result_score(const logosdb_search_result_t* r, int i)
+{
     return (r && i >= 0 && i < (int)r->hits.size()) ? r->hits[i].score : 0.0f;
 }
 
-const char * logosdb_result_text(const logosdb_search_result_t * r, int i) {
-    if (!r || i < 0 || i >= (int)r->hits.size()) return nullptr;
+const char* logosdb_result_text(const logosdb_search_result_t* r, int i)
+{
+    if (!r || i < 0 || i >= (int)r->hits.size())
+        return nullptr;
     return r->hits[i].text.empty() ? nullptr : r->hits[i].text.c_str();
 }
 
-const char * logosdb_result_timestamp(const logosdb_search_result_t * r, int i) {
-    if (!r || i < 0 || i >= (int)r->hits.size()) return nullptr;
+const char* logosdb_result_timestamp(const logosdb_search_result_t* r, int i)
+{
+    if (!r || i < 0 || i >= (int)r->hits.size())
+        return nullptr;
     return r->hits[i].timestamp.empty() ? nullptr : r->hits[i].timestamp.c_str();
 }
 
-void logosdb_result_free(logosdb_search_result_t * r) { delete r; }
+void logosdb_result_free(logosdb_search_result_t* r)
+{
+    delete r;
+}
 
 /* ── Info ──────────────────────────────────────────────────────────── */
 
-size_t logosdb_count(logosdb_t * db) {
+size_t logosdb_count(logosdb_t* db)
+{
     return db ? db->vectors.n_rows() : 0;
 }
 
-size_t logosdb_count_live(logosdb_t * db) {
-    if (!db) return 0;
-    size_t total   = db->vectors.n_rows();
+size_t logosdb_count_live(logosdb_t* db)
+{
+    if (!db)
+        return 0;
+    size_t total = db->vectors.n_rows();
     size_t deleted = db->meta.deleted_count();
     return total >= deleted ? total - deleted : 0;
 }
 
-int logosdb_dim(logosdb_t * db) {
+int logosdb_dim(logosdb_t* db)
+{
     return db ? db->dim : 0;
 }
 
-const float * logosdb_raw_vectors(logosdb_t * db, size_t * n_rows, int * dim) {
-    if (!db) { if (n_rows) *n_rows = 0; if (dim) *dim = 0; return nullptr; }
-    if (n_rows) *n_rows = db->vectors.n_rows();
-    if (dim)    *dim    = db->dim;
+const float* logosdb_raw_vectors(logosdb_t* db, size_t* n_rows, int* dim)
+{
+    if (!db)
+    {
+        if (n_rows)
+            *n_rows = 0;
+        if (dim)
+            *dim = 0;
+        return nullptr;
+    }
+    if (n_rows)
+        *n_rows = db->vectors.n_rows();
+    if (dim)
+        *dim = db->dim;
 
     // For reduced precision storage, we cannot return a direct pointer to float32 data
     // because the storage is in a different format. Users should use the C++ API or
     // individual row access for quantized storage.
     StorageDtype dtype = db->vectors.dtype();
-    if (dtype != DTYPE_FLOAT32) {
+    if (dtype != DTYPE_FLOAT32)
+    {
         // Return nullptr to indicate this API doesn't work with quantized storage
-        if (n_rows) *n_rows = 0;
-        if (dim) *dim = 0;
+        if (n_rows)
+            *n_rows = 0;
+        if (dim)
+            *dim = 0;
         return nullptr;
     }
-    return static_cast<const float *>(db->vectors.data_raw());
+    return static_cast<const float*>(db->vectors.data_raw());
 }
 
 /* ── Vector utilities ──────────────────────────────────────────────── */
 
 #include <cmath>
 
-int logosdb_l2_normalize(float * vec, int dim) {
-    if (!vec || dim <= 0) return -1;
+int logosdb_l2_normalize(float* vec, int dim)
+{
+    if (!vec || dim <= 0)
+        return -1;
 
     double sq_sum = 0.0;
-    for (int i = 0; i < dim; ++i) {
+    for (int i = 0; i < dim; ++i)
+    {
         sq_sum += (double)vec[i] * (double)vec[i];
     }
 
     double norm = std::sqrt(sq_sum);
-    if (norm == 0.0) return -1;  // Zero norm - cannot normalize
+    if (norm == 0.0)
+        return -1;  // Zero norm - cannot normalize
 
     float scale = (float)(1.0 / norm);
-    for (int i = 0; i < dim; ++i) {
+    for (int i = 0; i < dim; ++i)
+    {
         vec[i] *= scale;
     }
     return 0;
 }
 
 /* C++ convenience wrappers */
-namespace logosdb {
+namespace logosdb
+{
 
-bool l2_normalize(std::vector<float> & v) {
-    if (v.empty()) return false;
+bool l2_normalize(std::vector<float>& v)
+{
+    if (v.empty())
+        return false;
     return logosdb_l2_normalize(v.data(), (int)v.size()) == 0;
 }
 
-std::vector<float> l2_normalized(std::vector<float> v) {
+std::vector<float> l2_normalized(std::vector<float> v)
+{
     l2_normalize(v);
     return v;  // NRVO should elide the copy
 }
 
-} // namespace logosdb
+}  // namespace logosdb

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1,27 +1,33 @@
 #include "metadata.h"
 
-#include <nlohmann/json.hpp>
+#include <fcntl.h>
+#include <sys/types.h>
 
 #include <cerrno>
 #include <cstring>
 #include <fstream>
-#include <fcntl.h>
-#include <sys/types.h>
+#include <nlohmann/json.hpp>
 
 #ifdef _WIN32
-    #include <io.h>
+#include <io.h>
 #else
-    #include <unistd.h>
+#include <unistd.h>
 #endif
 
-namespace logosdb {
-namespace internal {
+namespace logosdb
+{
+namespace internal
+{
 
 using json = nlohmann::json;
 
-MetadataStore::~MetadataStore() { close(); }
+MetadataStore::~MetadataStore()
+{
+    close();
+}
 
-bool MetadataStore::open(const std::string & path, std::string & err) {
+bool MetadataStore::open(const std::string& path, std::string& err)
+{
     close();
     path_ = path;
 
@@ -31,30 +37,39 @@ bool MetadataStore::open(const std::string & path, std::string & err) {
     int flags = O_RDWR | O_CREAT | O_APPEND;
 #endif
     fd_ = ::open(path.c_str(), flags, 0644);
-    if (fd_ < 0) {
+    if (fd_ < 0)
+    {
         err = std::string("open meta: ") + strerror(errno);
         return false;
     }
 
     std::ifstream in(path);
-    if (in.good()) {
+    if (in.good())
+    {
         std::string line;
-        while (std::getline(in, line)) {
-            if (line.empty()) continue;
+        while (std::getline(in, line))
+        {
+            if (line.empty())
+                continue;
 
             // Try to parse as JSON
             json j;
-            try {
+            try
+            {
                 j = json::parse(line);
-            } catch (const json::exception & e) {
+            }
+            catch (const json::exception& e)
+            {
                 // Invalid JSON line - skip but don't fail
                 continue;
             }
 
             // Tombstone record: {"op":"del","id":N}
-            if (j.contains("op") && j["op"] == "del" && j.contains("id")) {
+            if (j.contains("op") && j["op"] == "del" && j.contains("id"))
+            {
                 uint64_t id = j["id"].get<uint64_t>();
-                if (id < rows_.size() && !rows_[id].deleted) {
+                if (id < rows_.size() && !rows_[id].deleted)
+                {
                     rows_[id].deleted = true;
                     ++num_deleted_;
                 }
@@ -63,10 +78,12 @@ bool MetadataStore::open(const std::string & path, std::string & err) {
 
             // Data row: {"text":"...","ts":"..."}
             MetaRow r;
-            if (j.contains("text")) {
+            if (j.contains("text"))
+            {
                 r.text = j["text"].get<std::string>();
             }
-            if (j.contains("ts")) {
+            if (j.contains("ts"))
+            {
                 r.timestamp = j["ts"].get<std::string>();
             }
             rows_.push_back(std::move(r));
@@ -75,8 +92,10 @@ bool MetadataStore::open(const std::string & path, std::string & err) {
     return true;
 }
 
-void MetadataStore::close() {
-    if (fd_ >= 0) {
+void MetadataStore::close()
+{
+    if (fd_ >= 0)
+    {
 #ifdef _WIN32
         _close(fd_);
 #else
@@ -89,9 +108,13 @@ void MetadataStore::close() {
     path_.clear();
 }
 
-uint64_t MetadataStore::append(const char * text, const char * timestamp,
-                                std::string & err) {
-    if (fd_ < 0) { err = "meta not open"; return UINT64_MAX; }
+uint64_t MetadataStore::append(const char* text, const char* timestamp, std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "meta not open";
+        return UINT64_MAX;
+    }
 
     json j;
     j["text"] = text ? text : "";
@@ -100,10 +123,12 @@ uint64_t MetadataStore::append(const char * text, const char * timestamp,
 
 #ifdef _WIN32
     int written = _write(fd_, line.data(), (int)line.size());
-    if (written != (int)line.size()) {
+    if (written != (int)line.size())
+    {
 #else
     ssize_t written = ::write(fd_, line.data(), line.size());
-    if (written != (ssize_t)line.size()) {
+    if (written != (ssize_t)line.size())
+    {
 #endif
         err = std::string("write meta: ") + strerror(errno);
         return UINT64_MAX;
@@ -114,16 +139,27 @@ uint64_t MetadataStore::append(const char * text, const char * timestamp,
     return id;
 }
 
-uint64_t MetadataStore::append_batch(const char * const * texts, const char * const * timestamps,
-                                      int n, std::string & err) {
-    if (fd_ < 0) { err = "meta not open"; return UINT64_MAX; }
-    if (n <= 0) { return rows_.size(); }
+uint64_t MetadataStore::append_batch(const char* const* texts,
+                                     const char* const* timestamps,
+                                     int n,
+                                     std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "meta not open";
+        return UINT64_MAX;
+    }
+    if (n <= 0)
+    {
+        return rows_.size();
+    }
 
     // Build all JSON lines and write in a single batch
     std::string batch;
     batch.reserve(n * 64);  // rough estimate
 
-    for (int i = 0; i < n; ++i) {
+    for (int i = 0; i < n; ++i)
+    {
         json j;
         j["text"] = texts && texts[i] ? texts[i] : "";
         j["ts"] = timestamps && timestamps[i] ? timestamps[i] : "";
@@ -133,32 +169,40 @@ uint64_t MetadataStore::append_batch(const char * const * texts, const char * co
 
 #ifdef _WIN32
     int written = _write(fd_, batch.data(), (int)batch.size());
-    if (written != (int)batch.size()) {
+    if (written != (int)batch.size())
+    {
 #else
     ssize_t written = ::write(fd_, batch.data(), batch.size());
-    if (written != (ssize_t)batch.size()) {
+    if (written != (ssize_t)batch.size())
+    {
 #endif
         err = std::string("write meta batch: ") + strerror(errno);
         return UINT64_MAX;
     }
 
     uint64_t start_id = rows_.size();
-    for (int i = 0; i < n; ++i) {
-        rows_.push_back({
-            texts && texts[i] ? texts[i] : "",
-            timestamps && timestamps[i] ? timestamps[i] : ""
-        });
+    for (int i = 0; i < n; ++i)
+    {
+        rows_.push_back(
+            {texts && texts[i] ? texts[i] : "", timestamps && timestamps[i] ? timestamps[i] : ""});
     }
     return start_id;
 }
 
-bool MetadataStore::mark_deleted(uint64_t id, std::string & err) {
-    if (fd_ < 0) { err = "meta not open"; return false; }
-    if (id >= rows_.size()) {
+bool MetadataStore::mark_deleted(uint64_t id, std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "meta not open";
+        return false;
+    }
+    if (id >= rows_.size())
+    {
         err = "delete: id out of range";
         return false;
     }
-    if (rows_[id].deleted) {
+    if (rows_[id].deleted)
+    {
         err = "delete: id already deleted";
         return false;
     }
@@ -170,10 +214,12 @@ bool MetadataStore::mark_deleted(uint64_t id, std::string & err) {
 
 #ifdef _WIN32
     int written = _write(fd_, line.data(), (int)line.size());
-    if (written != (int)line.size()) {
+    if (written != (int)line.size())
+    {
 #else
     ssize_t written = ::write(fd_, line.data(), line.size());
-    if (written != (ssize_t)line.size()) {
+    if (written != (ssize_t)line.size())
+    {
 #endif
         err = std::string("write tombstone: ") + strerror(errno);
         return false;
@@ -184,21 +230,31 @@ bool MetadataStore::mark_deleted(uint64_t id, std::string & err) {
     return true;
 }
 
-std::vector<uint64_t> MetadataStore::deleted_ids() const {
+std::vector<uint64_t> MetadataStore::deleted_ids() const
+{
     std::vector<uint64_t> out;
     out.reserve(num_deleted_);
-    for (size_t i = 0; i < rows_.size(); ++i) {
-        if (rows_[i].deleted) out.push_back((uint64_t)i);
+    for (size_t i = 0; i < rows_.size(); ++i)
+    {
+        if (rows_[i].deleted)
+            out.push_back((uint64_t)i);
     }
     return out;
 }
 
-bool MetadataStore::sync(std::string & err) {
-    if (fd_ < 0) { err = "meta not open"; return false; }
+bool MetadataStore::sync(std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "meta not open";
+        return false;
+    }
 #ifdef _WIN32
-    if (_commit(fd_) != 0) {
+    if (_commit(fd_) != 0)
+    {
 #else
-    if (::fsync(fd_) != 0) {
+    if (::fsync(fd_) != 0)
+    {
 #endif
         err = std::string("fsync meta: ") + strerror(errno);
         return false;
@@ -206,5 +262,5 @@ bool MetadataStore::sync(std::string & err) {
     return true;
 }
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -4,13 +4,16 @@
 #include <string>
 #include <vector>
 
-namespace logosdb {
-namespace internal {
+namespace logosdb
+{
+namespace internal
+{
 
-struct MetaRow {
+struct MetaRow
+{
     std::string text;
     std::string timestamp;
-    bool        deleted = false;
+    bool deleted = false;
 };
 
 // Append-only JSONL metadata store.
@@ -20,50 +23,47 @@ struct MetaRow {
 //
 // Tombstones mark an earlier data row as logically deleted. They do not
 // occupy a row index themselves.
-class MetadataStore {
-public:
+class MetadataStore
+{
+  public:
     MetadataStore() = default;
     ~MetadataStore();
 
-    MetadataStore(const MetadataStore &) = delete;
-    MetadataStore & operator=(const MetadataStore &) = delete;
+    MetadataStore(const MetadataStore&) = delete;
+    MetadataStore& operator=(const MetadataStore&) = delete;
 
-    bool open(const std::string & path, std::string & err);
+    bool open(const std::string& path, std::string& err);
     void close();
 
-    uint64_t append(const char * text, const char * timestamp, std::string & err);
+    uint64_t append(const char* text, const char* timestamp, std::string& err);
 
     /* Append n metadata rows efficiently. Returns the starting id, or UINT64_MAX on error. */
-    uint64_t append_batch(const char * const * texts, const char * const * timestamps,
-                          int n, std::string & err);
+    uint64_t
+    append_batch(const char* const* texts, const char* const* timestamps, int n, std::string& err);
 
     // Append a tombstone for `id`. Returns false if the id is out of range
     // or already deleted. `err` is set on failure.
-    bool mark_deleted(uint64_t id, std::string & err);
+    bool mark_deleted(uint64_t id, std::string& err);
 
-    size_t count()         const { return rows_.size(); }
+    size_t count() const { return rows_.size(); }
     size_t deleted_count() const { return num_deleted_; }
 
-    bool is_deleted(uint64_t id) const {
-        return id < rows_.size() && rows_[id].deleted;
-    }
+    bool is_deleted(uint64_t id) const { return id < rows_.size() && rows_[id].deleted; }
 
-    const MetaRow * row(uint64_t idx) const {
-        return idx < rows_.size() ? &rows_[idx] : nullptr;
-    }
+    const MetaRow* row(uint64_t idx) const { return idx < rows_.size() ? &rows_[idx] : nullptr; }
 
     // Iterate over all currently-tombstoned ids. Used by the DB on open to
     // re-apply deletion marks to a freshly-rebuilt HNSW index.
     std::vector<uint64_t> deleted_ids() const;
 
-    bool sync(std::string & err);
+    bool sync(std::string& err);
 
-private:
-    std::string           path_;
-    int                   fd_ = -1;
-    std::vector<MetaRow>  rows_;
-    size_t                num_deleted_ = 0;
+  private:
+    std::string path_;
+    int fd_ = -1;
+    std::vector<MetaRow> rows_;
+    size_t num_deleted_ = 0;
 };
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -1,22 +1,27 @@
 #include "platform.h"
 
-#include <cerrno>
-#include <cstring>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cerrno>
+#include <cstring>
+
 #ifdef _WIN32
-    #include <io.h>
+#include <io.h>
 #else
-    #include <unistd.h>
+#include <unistd.h>
 #endif
 
-namespace logosdb {
-namespace internal {
-namespace platform {
+namespace logosdb
+{
+namespace internal
+{
+namespace platform
+{
 
-bool file_exists(const std::string& path) {
+bool file_exists(const std::string& path)
+{
 #ifdef _WIN32
     struct _stat st;
     return _stat(path.c_str(), &st) == 0;
@@ -29,32 +34,34 @@ bool file_exists(const std::string& path) {
 #ifdef _WIN32
 // Windows memory mapping implementation
 
-bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, std::string& err) {
-    out_map = {}; // Clear
+bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, std::string& err)
+{
+    out_map = {};  // Clear
 
-    HANDLE file_handle = CreateFileA(
-        path.c_str(),
-        GENERIC_READ,
-        FILE_SHARE_READ,
-        nullptr,
-        OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL,
-        nullptr
-    );
+    HANDLE file_handle = CreateFileA(path.c_str(),
+                                     GENERIC_READ,
+                                     FILE_SHARE_READ,
+                                     nullptr,
+                                     OPEN_EXISTING,
+                                     FILE_ATTRIBUTE_NORMAL,
+                                     nullptr);
 
-    if (file_handle == INVALID_HANDLE_VALUE) {
+    if (file_handle == INVALID_HANDLE_VALUE)
+    {
         err = "CreateFileA failed: " + std::to_string(GetLastError());
         return false;
     }
 
     LARGE_INTEGER file_size;
-    if (!GetFileSizeEx(file_handle, &file_size)) {
+    if (!GetFileSizeEx(file_handle, &file_size))
+    {
         err = "GetFileSizeEx failed: " + std::to_string(GetLastError());
         CloseHandle(file_handle);
         return false;
     }
 
-    if (file_size.QuadPart == 0) {
+    if (file_size.QuadPart == 0)
+    {
         // Empty file - no mapping needed
         out_map.file_handle = file_handle;
         out_map.data = nullptr;
@@ -63,30 +70,19 @@ bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, s
         return true;
     }
 
-    HANDLE map_handle = CreateFileMapping(
-        file_handle,
-        nullptr,
-        PAGE_READONLY,
-        0,
-        0,
-        nullptr
-    );
+    HANDLE map_handle = CreateFileMapping(file_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
 
-    if (map_handle == INVALID_HANDLE_VALUE) {
+    if (map_handle == INVALID_HANDLE_VALUE)
+    {
         err = "CreateFileMapping failed: " + std::to_string(GetLastError());
         CloseHandle(file_handle);
         return false;
     }
 
-    void* data = MapViewOfFile(
-        map_handle,
-        FILE_MAP_READ,
-        0,
-        0,
-        0
-    );
+    void* data = MapViewOfFile(map_handle, FILE_MAP_READ, 0, 0, 0);
 
-    if (!data) {
+    if (!data)
+    {
         err = "MapViewOfFile failed: " + std::to_string(GetLastError());
         CloseHandle(map_handle);
         CloseHandle(file_handle);
@@ -101,23 +97,28 @@ bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, s
     return true;
 }
 
-void mmap_close(MappedFile& map) {
-    if (map.data) {
+void mmap_close(MappedFile& map)
+{
+    if (map.data)
+    {
         UnmapViewOfFile(map.data);
         map.data = nullptr;
     }
-    if (map.map_handle != INVALID_HANDLE_VALUE) {
+    if (map.map_handle != INVALID_HANDLE_VALUE)
+    {
         CloseHandle(map.map_handle);
         map.map_handle = INVALID_HANDLE_VALUE;
     }
-    if (map.file_handle != INVALID_HANDLE_VALUE) {
+    if (map.file_handle != INVALID_HANDLE_VALUE)
+    {
         CloseHandle(map.file_handle);
         map.file_handle = INVALID_HANDLE_VALUE;
     }
     map.size = 0;
 }
 
-bool mmap_resize(MappedFile& map, size_t new_size, std::string& err) {
+bool mmap_resize(MappedFile& map, size_t new_size, std::string& err)
+{
     // On Windows, we need to close and reopen the mapping
     // This is used when the file grows
     mmap_close(map);
@@ -128,27 +129,32 @@ bool mmap_resize(MappedFile& map, size_t new_size, std::string& err) {
     return false;
 }
 
-bool mmap_reserve(const std::string& path, size_t reserve_size, MappedFile& out_map, std::string& err) {
-    out_map = {}; // Clear
+bool mmap_reserve(const std::string& path,
+                  size_t reserve_size,
+                  MappedFile& out_map,
+                  std::string& err)
+{
+    out_map = {};  // Clear
 
     // First, get the current file size
-    HANDLE file_handle = CreateFileA(
-        path.c_str(),
-        GENERIC_READ,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,  // Allow others to write (file growth)
-        nullptr,
-        OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL,
-        nullptr
-    );
+    HANDLE file_handle =
+        CreateFileA(path.c_str(),
+                    GENERIC_READ,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE,  // Allow others to write (file growth)
+                    nullptr,
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL,
+                    nullptr);
 
-    if (file_handle == INVALID_HANDLE_VALUE) {
+    if (file_handle == INVALID_HANDLE_VALUE)
+    {
         err = "CreateFileA failed: " + std::to_string(GetLastError());
         return false;
     }
 
     LARGE_INTEGER file_size;
-    if (!GetFileSizeEx(file_handle, &file_size)) {
+    if (!GetFileSizeEx(file_handle, &file_size))
+    {
         err = "GetFileSizeEx failed: " + std::to_string(GetLastError());
         CloseHandle(file_handle);
         return false;
@@ -156,31 +162,31 @@ bool mmap_reserve(const std::string& path, size_t reserve_size, MappedFile& out_
 
     // Create a file mapping that reserves virtual address space
     // We use a large maximum size for reservation, but only commit what's needed
-    HANDLE map_handle = CreateFileMapping(
-        file_handle,
-        nullptr,
-        PAGE_READONLY,
-        0,
-        static_cast<DWORD>(reserve_size),  // Maximum size for reservation
-        nullptr
-    );
+    HANDLE map_handle =
+        CreateFileMapping(file_handle,
+                          nullptr,
+                          PAGE_READONLY,
+                          0,
+                          static_cast<DWORD>(reserve_size),  // Maximum size for reservation
+                          nullptr);
 
-    if (map_handle == INVALID_HANDLE_VALUE) {
+    if (map_handle == INVALID_HANDLE_VALUE)
+    {
         err = "CreateFileMapping failed: " + std::to_string(GetLastError());
         CloseHandle(file_handle);
         return false;
     }
 
     // Map only the current file size initially
-    void* data = MapViewOfFile(
-        map_handle,
-        FILE_MAP_READ,
-        0,
-        0,
-        static_cast<size_t>(file_size.QuadPart)  // Initial view size
+    void* data = MapViewOfFile(map_handle,
+                               FILE_MAP_READ,
+                               0,
+                               0,
+                               static_cast<size_t>(file_size.QuadPart)  // Initial view size
     );
 
-    if (!data) {
+    if (!data)
+    {
         err = "MapViewOfFile failed: " + std::to_string(GetLastError());
         CloseHandle(map_handle);
         CloseHandle(file_handle);
@@ -194,24 +200,26 @@ bool mmap_reserve(const std::string& path, size_t reserve_size, MappedFile& out_
     return true;
 }
 
-size_t mmap_commit(MappedFile& map, size_t file_size) {
+size_t mmap_commit(MappedFile& map, size_t file_size)
+{
 #ifdef _WIN32
     // On Windows with file mapping, the view automatically extends
     // when the file grows (as long as we're within the mapping's max size)
     // We just need to unmap and remap to the new size
-    if (map.data) {
+    if (map.data)
+    {
         UnmapViewOfFile(map.data);
     }
 
-    void* data = MapViewOfFile(
-        map.map_handle,
-        FILE_MAP_READ,
-        0,
-        0,
-        file_size  // New view size
+    void* data = MapViewOfFile(map.map_handle,
+                               FILE_MAP_READ,
+                               0,
+                               0,
+                               file_size  // New view size
     );
 
-    if (!data) {
+    if (!data)
+    {
         return map.size;  // Failed, keep old size
     }
 
@@ -227,17 +235,20 @@ size_t mmap_commit(MappedFile& map, size_t file_size) {
 #else
 // POSIX memory mapping implementation (Linux/macOS)
 
-bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, std::string& err) {
-    out_map = {}; // Clear
+bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, std::string& err)
+{
+    out_map = {};  // Clear
 
     int fd = ::open(path.c_str(), O_RDONLY);
-    if (fd < 0) {
+    if (fd < 0)
+    {
         err = std::string("open: ") + strerror(errno);
         return false;
     }
 
     struct stat st;
-    if (fstat(fd, &st) != 0) {
+    if (fstat(fd, &st) != 0)
+    {
         err = std::string("fstat: ") + strerror(errno);
         ::close(fd);
         return false;
@@ -245,7 +256,8 @@ bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, s
 
     size_t size = static_cast<size_t>(st.st_size);
 
-    if (size == 0) {
+    if (size == 0)
+    {
         // Empty file - no mapping needed
         out_map.fd = fd;
         out_map.data = nullptr;
@@ -255,7 +267,8 @@ bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, s
     }
 
     void* data = mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
-    if (data == MAP_FAILED) {
+    if (data == MAP_FAILED)
+    {
         err = std::string("mmap: ") + strerror(errno);
         ::close(fd);
         return false;
@@ -268,11 +281,14 @@ bool mmap_open(const std::string& path, size_t& out_size, MappedFile& out_map, s
     return true;
 }
 
-void mmap_close(MappedFile& map) {
-    if (map.data && map.size > 0) {
+void mmap_close(MappedFile& map)
+{
+    if (map.data && map.size > 0)
+    {
         munmap(map.data, map.size);
     }
-    if (map.fd >= 0) {
+    if (map.fd >= 0)
+    {
         ::close(map.fd);
     }
     map.data = nullptr;
@@ -280,14 +296,17 @@ void mmap_close(MappedFile& map) {
     map.size = 0;
 }
 
-bool mmap_resize(MappedFile& map, size_t new_size, std::string& err) {
+bool mmap_resize(MappedFile& map, size_t new_size, std::string& err)
+{
     // On POSIX, unmap and remap
-    if (map.data && map.size > 0) {
+    if (map.data && map.size > 0)
+    {
         munmap(map.data, map.size);
     }
 
     void* data = mmap(nullptr, new_size, PROT_READ, MAP_SHARED, map.fd, 0);
-    if (data == MAP_FAILED) {
+    if (data == MAP_FAILED)
+    {
         err = std::string("mmap resize: ") + strerror(errno);
         return false;
     }
@@ -298,7 +317,11 @@ bool mmap_resize(MappedFile& map, size_t new_size, std::string& err) {
 }
 
 // Stub implementations for POSIX - reservation is handled directly in storage.cpp
-bool mmap_reserve(const std::string& path, size_t reserve_size, MappedFile& out_map, std::string& err) {
+bool mmap_reserve(const std::string& path,
+                  size_t reserve_size,
+                  MappedFile& out_map,
+                  std::string& err)
+{
     (void)path;
     (void)reserve_size;
     (void)out_map;
@@ -306,13 +329,14 @@ bool mmap_reserve(const std::string& path, size_t reserve_size, MappedFile& out_
     return false;
 }
 
-size_t mmap_commit(MappedFile& map, size_t file_size) {
+size_t mmap_commit(MappedFile& map, size_t file_size)
+{
     (void)map;
     return file_size;
 }
 
 #endif
 
-} // namespace platform
-} // namespace internal
-} // namespace logosdb
+}  // namespace platform
+}  // namespace internal
+}  // namespace logosdb

--- a/src/platform.h
+++ b/src/platform.h
@@ -4,28 +4,32 @@
 // Handles differences between POSIX (Linux/macOS) and Windows
 
 #ifdef _WIN32
-    #define LOGOSDB_WINDOWS
-    #define NOMINMAX
-    #include <windows.h>
-    #include <io.h>
-    #include <direct.h>
+#define LOGOSDB_WINDOWS
+#define NOMINMAX
+#include <direct.h>
+#include <io.h>
+#include <windows.h>
 #else
-    #define LOGOSDB_POSIX
-    #include <unistd.h>
-    #include <sys/mman.h>
-    #include <string.h>  // For strdup
+#define LOGOSDB_POSIX
+#include <string.h>  // For strdup
+#include <sys/mman.h>
+#include <unistd.h>
 #endif
 
 #include <cstddef>
 #include <cstdint>
 #include <string>
 
-namespace logosdb {
-namespace internal {
-namespace platform {
+namespace logosdb
+{
+namespace internal
+{
+namespace platform
+{
 
 // Memory-mapped file abstraction
-struct MappedFile {
+struct MappedFile
+{
 #ifdef LOGOSDB_WINDOWS
     HANDLE file_handle = INVALID_HANDLE_VALUE;
     HANDLE map_handle = INVALID_HANDLE_VALUE;
@@ -47,7 +51,10 @@ bool mmap_resize(MappedFile& map, size_t new_size, std::string& err);
 void mmap_close(MappedFile& map);
 
 // Reservation mapping (for avoiding remap on append)
-bool mmap_reserve(const std::string& path, size_t reserve_size, MappedFile& out_map, std::string& err);
+bool mmap_reserve(const std::string& path,
+                  size_t reserve_size,
+                  MappedFile& out_map,
+                  std::string& err);
 size_t mmap_commit(MappedFile& map, size_t file_size);  // Returns actual committed size
 
 // String utilities
@@ -55,27 +62,33 @@ char* string_duplicate(const char* str);
 
 // Platform-specific wrapper macros
 #ifdef _WIN32
-    inline bool file_truncate(int fd, size_t size) {
-        return _chsize_s(fd, size) == 0;
-    }
-    inline int file_sync(int fd) {
-        return _commit(fd);
-    }
-    inline char* string_duplicate(const char* str) {
-        return _strdup(str);
-    }
+inline bool file_truncate(int fd, size_t size)
+{
+    return _chsize_s(fd, size) == 0;
+}
+inline int file_sync(int fd)
+{
+    return _commit(fd);
+}
+inline char* string_duplicate(const char* str)
+{
+    return _strdup(str);
+}
 #else
-    inline bool file_truncate(int fd, size_t size) {
-        return ftruncate(fd, size) == 0;
-    }
-    inline int file_sync(int fd) {
-        return fsync(fd);
-    }
-    inline char* string_duplicate(const char* str) {
-        return strdup(str);
-    }
+inline bool file_truncate(int fd, size_t size)
+{
+    return ftruncate(fd, size) == 0;
+}
+inline int file_sync(int fd)
+{
+    return fsync(fd);
+}
+inline char* string_duplicate(const char* str)
+{
+    return strdup(str);
+}
 #endif
 
-} // namespace platform
-} // namespace internal
-} // namespace logosdb
+}  // namespace platform
+}  // namespace internal
+}  // namespace logosdb

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1,36 +1,51 @@
 #include "storage.h"
+
 #include "platform.h"
 
-#include <cerrno>
-#include <cmath>
-#include <cstring>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cerrno>
+#include <cmath>
+#include <cstring>
+
 #ifdef _WIN32
-    #include <io.h>
+#include <io.h>
 #else
-    #include <unistd.h>
+#include <unistd.h>
 #endif
 
-namespace logosdb {
-namespace internal {
+namespace logosdb
+{
+namespace internal
+{
 
 /* ── Dtype utilities ─────────────────────────────────────────────────── */
 
-size_t dtype_size(StorageDtype dtype) {
-    switch (dtype) {
-        case DTYPE_FLOAT16: return 2;
-        case DTYPE_INT8:    return 1;
-        case DTYPE_FLOAT32: default: return 4;
+size_t dtype_size(StorageDtype dtype)
+{
+    switch (dtype)
+    {
+    case DTYPE_FLOAT16:
+        return 2;
+    case DTYPE_INT8:
+        return 1;
+    case DTYPE_FLOAT32:
+    default:
+        return 4;
     }
 }
 
 // IEEE 754 float32 to float16 conversion
-uint16_t float32_to_float16(float f) {
+uint16_t float32_to_float16(float f)
+{
     // Bit-level reinterpretation
-    union { float f; uint32_t u; } v = { f };
+    union
+    {
+        float f;
+        uint32_t u;
+    } v = {f};
     uint32_t u = v.u;
 
     uint32_t sign = (u >> 31) & 0x1;
@@ -38,20 +53,26 @@ uint16_t float32_to_float16(float f) {
     uint32_t mant = u & 0x7FFFFF;
 
     // Handle special cases
-    if (exp == 0xFF) {  // Inf or NaN
-        if (mant != 0) return (sign << 15) | 0x7C00 | (mant >> 13);  // NaN
-        return (sign << 15) | 0x7C00;  // Inf
+    if (exp == 0xFF)
+    {  // Inf or NaN
+        if (mant != 0)
+            return (sign << 15) | 0x7C00 | (mant >> 13);  // NaN
+        return (sign << 15) | 0x7C00;                     // Inf
     }
 
     // Convert exponent
     int32_t new_exp = (int32_t)exp - 127 + 15;
 
-    if (new_exp >= 31) {
+    if (new_exp >= 31)
+    {
         // Overflow to infinity
         return (sign << 15) | 0x7C00;
-    } else if (new_exp <= 0) {
+    }
+    else if (new_exp <= 0)
+    {
         // Underflow to zero or denormal
-        if (new_exp < -10) {
+        if (new_exp < -10)
+        {
             return sign << 15;  // Zero
         }
         // Denormal
@@ -63,113 +84,155 @@ uint16_t float32_to_float16(float f) {
     return (sign << 15) | (new_exp << 10) | (mant >> 13);
 }
 
-float float16_to_float32(uint16_t h) {
+float float16_to_float32(uint16_t h)
+{
     uint32_t sign = (h >> 15) & 0x1;
     uint32_t exp = (h >> 10) & 0x1F;
     uint32_t mant = h & 0x3FF;
 
-    if (exp == 0) {
-        if (mant == 0) {
+    if (exp == 0)
+    {
+        if (mant == 0)
+        {
             // Zero
             return sign ? -0.0f : 0.0f;
         }
         // Denormal
         float f = mant / 1024.0f;
         return sign ? -f * 0.00006103515625f : f * 0.00006103515625f;
-    } else if (exp == 31) {
-        if (mant != 0) {
+    }
+    else if (exp == 31)
+    {
+        if (mant != 0)
+        {
             // NaN
-            union { uint32_t u; float f; } v = { (sign << 31) | 0x7FC00000 | (mant << 13) };
+            union
+            {
+                uint32_t u;
+                float f;
+            } v = {(sign << 31) | 0x7FC00000 | (mant << 13)};
             return v.f;
         }
         // Inf
-        union { uint32_t u; float f; } v = { (sign << 31) | 0x7F800000 };
+        union
+        {
+            uint32_t u;
+            float f;
+        } v = {(sign << 31) | 0x7F800000};
         return v.f;
     }
 
     // Normal
     uint32_t u = (sign << 31) | ((exp + 112) << 23) | (mant << 13);
-    union { uint32_t u; float f; } v = { u };
+    union
+    {
+        uint32_t u;
+        float f;
+    } v = {u};
     return v.f;
 }
 
-void quantize_float32_to_int8(const float * src, int8_t * dst, int dim, float scale) {
-    if (scale == 0.0f) {
-        for (int i = 0; i < dim; ++i) dst[i] = 0;
+void quantize_float32_to_int8(const float* src, int8_t* dst, int dim, float scale)
+{
+    if (scale == 0.0f)
+    {
+        for (int i = 0; i < dim; ++i)
+            dst[i] = 0;
         return;
     }
     float inv_scale = 127.0f / scale;
-    for (int i = 0; i < dim; ++i) {
+    for (int i = 0; i < dim; ++i)
+    {
         int32_t val = (int32_t)std::round(src[i] * inv_scale);
         // Clamp to [-127, 127] (reserve -128 for future)
-        if (val > 127) val = 127;
-        if (val < -127) val = -127;
+        if (val > 127)
+            val = 127;
+        if (val < -127)
+            val = -127;
         dst[i] = (int8_t)val;
     }
 }
 
-void dequantize_int8_to_float32(const int8_t * src, float * dst, int dim, float scale) {
+void dequantize_int8_to_float32(const int8_t* src, float* dst, int dim, float scale)
+{
     float scale_127 = scale / 127.0f;
-    for (int i = 0; i < dim; ++i) {
+    for (int i = 0; i < dim; ++i)
+    {
         dst[i] = (float)src[i] * scale_127;
     }
 }
 
-float compute_int8_scale(const float * vec, int dim) {
+float compute_int8_scale(const float* vec, int dim)
+{
     float max_abs = 0.0f;
-    for (int i = 0; i < dim; ++i) {
+    for (int i = 0; i < dim; ++i)
+    {
         float abs_val = std::abs(vec[i]);
-        if (abs_val > max_abs) max_abs = abs_val;
+        if (abs_val > max_abs)
+            max_abs = abs_val;
     }
     return max_abs;
 }
 
 /* ── VectorStorage implementation ───────────────────────────────────── */
 
-static size_t row_stride(int dim, StorageDtype dtype) {
+static size_t row_stride(int dim, StorageDtype dtype)
+{
     return (size_t)dim * dtype_size(dtype);
 }
 
-static bool checked_file_size(uint64_t n_rows, int dim, StorageDtype dtype, size_t & out) {
+static bool checked_file_size(uint64_t n_rows, int dim, StorageDtype dtype, size_t& out)
+{
     size_t stride = row_stride(dim, dtype);
-    if (stride > 0 && n_rows > (SIZE_MAX - sizeof(StorageHeader)) / stride) {
-        return false; // would overflow
+    if (stride > 0 && n_rows > (SIZE_MAX - sizeof(StorageHeader)) / stride)
+    {
+        return false;  // would overflow
     }
     out = sizeof(StorageHeader) + n_rows * stride;
     return true;
 }
 
 #ifdef _WIN32
-static int64_t file_pwrite(int fd, const void* buf, size_t count, size_t offset) {
-    if (_lseeki64(fd, static_cast<__int64>(offset), SEEK_SET) < 0) {
+static int64_t file_pwrite(int fd, const void* buf, size_t count, size_t offset)
+{
+    if (_lseeki64(fd, static_cast<__int64>(offset), SEEK_SET) < 0)
+    {
         return -1;
     }
     int written = _write(fd, buf, static_cast<unsigned int>(count));
     return written < 0 ? -1 : static_cast<int64_t>(written);
 }
 
-static int64_t file_pread(int fd, void* buf, size_t count, size_t offset) {
-    if (_lseeki64(fd, static_cast<__int64>(offset), SEEK_SET) < 0) {
+static int64_t file_pread(int fd, void* buf, size_t count, size_t offset)
+{
+    if (_lseeki64(fd, static_cast<__int64>(offset), SEEK_SET) < 0)
+    {
         return -1;
     }
     int read_bytes = _read(fd, buf, static_cast<unsigned int>(count));
     return read_bytes < 0 ? -1 : static_cast<int64_t>(read_bytes);
 }
 #else
-static int64_t file_pwrite(int fd, const void* buf, size_t count, size_t offset) {
+static int64_t file_pwrite(int fd, const void* buf, size_t count, size_t offset)
+{
     ssize_t written = ::pwrite(fd, buf, count, static_cast<off_t>(offset));
     return written < 0 ? -1 : static_cast<int64_t>(written);
 }
 
-static int64_t file_pread(int fd, void* buf, size_t count, size_t offset) {
+static int64_t file_pread(int fd, void* buf, size_t count, size_t offset)
+{
     ssize_t read_bytes = ::pread(fd, buf, count, static_cast<off_t>(offset));
     return read_bytes < 0 ? -1 : static_cast<int64_t>(read_bytes);
 }
 #endif
 
-VectorStorage::~VectorStorage() { close(); }
+VectorStorage::~VectorStorage()
+{
+    close();
+}
 
-bool VectorStorage::open(const std::string & path, int dim, StorageDtype dtype, std::string & err) {
+bool VectorStorage::open(const std::string& path, int dim, StorageDtype dtype, std::string& err)
+{
     close();
     path_ = path;
 
@@ -179,20 +242,23 @@ bool VectorStorage::open(const std::string & path, int dim, StorageDtype dtype, 
     int flags = O_RDWR | O_CREAT;
 #endif
     fd_ = ::open(path.c_str(), flags, 0644);
-    if (fd_ < 0) {
+    if (fd_ < 0)
+    {
         err = std::string("open: ") + strerror(errno);
         return false;
     }
 
     struct stat st;
-    if (fstat(fd_, &st) != 0) {
+    if (fstat(fd_, &st) != 0)
+    {
         err = std::string("fstat: ") + strerror(errno);
         close();
         return false;
     }
     file_size_ = (size_t)st.st_size;
 
-    if (file_size_ == 0) {
+    if (file_size_ == 0)
+    {
         // Create new file with specified dtype
         header_ = {};
         header_.version = 2;
@@ -200,42 +266,52 @@ bool VectorStorage::open(const std::string & path, int dim, StorageDtype dtype, 
         header_.dtype = (uint32_t)dtype;
         header_.n_rows = 0;
         header_.scale = 1.0f;
-        if (!platform::file_truncate(fd_, sizeof(StorageHeader))) {
+        if (!platform::file_truncate(fd_, sizeof(StorageHeader)))
+        {
             err = std::string("ftruncate: ") + strerror(errno);
             close();
             return false;
         }
-        if (file_pwrite(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_))) {
+        if (file_pwrite(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_)))
+        {
             err = "failed to write header";
             close();
             return false;
         }
         file_size_ = sizeof(StorageHeader);
-    } else {
-        if (file_size_ < sizeof(StorageHeader)) {
+    }
+    else
+    {
+        if (file_size_ < sizeof(StorageHeader))
+        {
             err = "file too small for header";
             close();
             return false;
         }
-        if (file_pread(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_))) {
+        if (file_pread(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_)))
+        {
             err = "failed to read header";
             close();
             return false;
         }
-        if (header_.magic != 0x4C4F474F) {
+        if (header_.magic != 0x4C4F474F)
+        {
             err = "bad magic";
             close();
             return false;
         }
 
         // Handle version compatibility
-        if (header_.version == 0 || header_.version == 1) {
+        if (header_.version == 0 || header_.version == 1)
+        {
             // v1 files are float32 only - upgrade to v2 in memory
             header_.version = 2;
             header_.dtype = DTYPE_FLOAT32;
             header_.scale = 1.0f;
             header_.reserved = 0.0f;
-        } else if (header_.version != 2) {
+        }
+        else if (header_.version != 2)
+        {
             err = "unsupported file version: " + std::to_string(header_.version);
             close();
             return false;
@@ -243,41 +319,47 @@ bool VectorStorage::open(const std::string & path, int dim, StorageDtype dtype, 
 
         // Check dtype compatibility
         StorageDtype file_dtype = static_cast<StorageDtype>(header_.dtype);
-        if (file_dtype != dtype && file_dtype != DTYPE_FLOAT32) {
+        if (file_dtype != dtype && file_dtype != DTYPE_FLOAT32)
+        {
             // Allow opening existing files even if requested dtype differs
             // We'll use the file's dtype
         }
 
-        if (header_.dim != (uint32_t)dim && dim > 0 && header_.dim > 0) {
+        if (header_.dim != (uint32_t)dim && dim > 0 && header_.dim > 0)
+        {
             err = "dimension mismatch (file=" + std::to_string(header_.dim) +
                   " requested=" + std::to_string(dim) + ")";
             close();
             return false;
         }
-        if (dim > 0 && header_.dim == 0) {
+        if (dim > 0 && header_.dim == 0)
+        {
             header_.dim = (uint32_t)dim;
         }
         // Validate n_rows against actual file size to detect corruption.
         size_t expected_size = 0;
-        if (!checked_file_size(header_.n_rows, (int)header_.dim, file_dtype, expected_size)
-            || expected_size > file_size_) {
+        if (!checked_file_size(header_.n_rows, (int)header_.dim, file_dtype, expected_size) ||
+            expected_size > file_size_)
+        {
             size_t stride = row_stride((int)header_.dim, file_dtype);
-            uint64_t max_rows = stride > 0
-                ? (file_size_ - sizeof(StorageHeader)) / stride : 0;
+            uint64_t max_rows = stride > 0 ? (file_size_ - sizeof(StorageHeader)) / stride : 0;
             header_.n_rows = max_rows;
         }
     }
 
-    if (!reserve_mapping(file_size_, err)) {
+    if (!reserve_mapping(file_size_, err))
+    {
         close();
         return false;
     }
     return true;
 }
 
-void VectorStorage::close() {
+void VectorStorage::close()
+{
     unmap();
-    if (fd_ >= 0) {
+    if (fd_ >= 0)
+    {
 #ifdef _WIN32
         _close(fd_);
 #else
@@ -290,51 +372,69 @@ void VectorStorage::close() {
     reserved_size_ = 0;
 }
 
-uint64_t VectorStorage::append(const float * vec, int dim, std::string & err) {
-    if (fd_ < 0) { err = "not open"; return UINT64_MAX; }
-    if ((uint32_t)dim != header_.dim) {
+uint64_t VectorStorage::append(const float* vec, int dim, std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "not open";
+        return UINT64_MAX;
+    }
+    if ((uint32_t)dim != header_.dim)
+    {
         err = "dim mismatch on append";
         return UINT64_MAX;
     }
 
     StorageDtype dtype = static_cast<StorageDtype>(header_.dtype);
     size_t new_size = 0;
-    if (!checked_file_size(header_.n_rows + 1, dim, dtype, new_size)) {
+    if (!checked_file_size(header_.n_rows + 1, dim, dtype, new_size))
+    {
         err = "storage size overflow";
         return UINT64_MAX;
     }
     size_t stride = row_stride(dim, dtype);
     size_t offset = new_size - stride;
 
-    if (!platform::file_truncate(fd_, new_size)) {
+    if (!platform::file_truncate(fd_, new_size))
+    {
         err = std::string("ftruncate: ") + strerror(errno);
         return UINT64_MAX;
     }
 
     // Convert and write based on dtype
-    if (dtype == DTYPE_FLOAT32) {
-        if (file_pwrite(fd_, vec, stride, offset) != static_cast<int64_t>(stride)) {
+    if (dtype == DTYPE_FLOAT32)
+    {
+        if (file_pwrite(fd_, vec, stride, offset) != static_cast<int64_t>(stride))
+        {
             err = "pwrite vec failed";
             return UINT64_MAX;
         }
-    } else if (dtype == DTYPE_FLOAT16) {
+    }
+    else if (dtype == DTYPE_FLOAT16)
+    {
         std::vector<uint16_t> half(dim);
-        for (int i = 0; i < dim; ++i) {
+        for (int i = 0; i < dim; ++i)
+        {
             half[i] = float32_to_float16(vec[i]);
         }
-        if (file_pwrite(fd_, half.data(), stride, offset) != static_cast<int64_t>(stride)) {
+        if (file_pwrite(fd_, half.data(), stride, offset) != static_cast<int64_t>(stride))
+        {
             err = "pwrite float16 vec failed";
             return UINT64_MAX;
         }
-    } else if (dtype == DTYPE_INT8) {
+    }
+    else if (dtype == DTYPE_INT8)
+    {
         // Update global scale if needed
         float vec_scale = compute_int8_scale(vec, dim);
-        if (vec_scale > header_.scale) {
+        if (vec_scale > header_.scale)
+        {
             header_.scale = vec_scale;
         }
         std::vector<int8_t> quantized(dim);
         quantize_float32_to_int8(vec, quantized.data(), dim, header_.scale);
-        if (file_pwrite(fd_, quantized.data(), stride, offset) != static_cast<int64_t>(stride)) {
+        if (file_pwrite(fd_, quantized.data(), stride, offset) != static_cast<int64_t>(stride))
+        {
             err = "pwrite int8 vec failed";
             return UINT64_MAX;
         }
@@ -344,33 +444,46 @@ uint64_t VectorStorage::append(const float * vec, int dim, std::string & err) {
     header_.n_rows++;
     file_size_ = new_size;
 
-    if (file_pwrite(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_))) {
+    if (file_pwrite(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_)))
+    {
         err = "pwrite header failed";
         return UINT64_MAX;
     }
 
     // Extend mapping if file grew beyond current mapping
-    if (!extend_mapping_if_needed(err)) return UINT64_MAX;
+    if (!extend_mapping_if_needed(err))
+        return UINT64_MAX;
     return id;
 }
 
-uint64_t VectorStorage::append_batch(const float * data, int n, int dim, std::string & err) {
-    if (fd_ < 0) { err = "not open"; return UINT64_MAX; }
-    if (n <= 0) { return header_.n_rows; }
-    if ((uint32_t)dim != header_.dim) {
+uint64_t VectorStorage::append_batch(const float* data, int n, int dim, std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "not open";
+        return UINT64_MAX;
+    }
+    if (n <= 0)
+    {
+        return header_.n_rows;
+    }
+    if ((uint32_t)dim != header_.dim)
+    {
         err = "dim mismatch on batch append";
         return UINT64_MAX;
     }
 
     StorageDtype dtype = static_cast<StorageDtype>(header_.dtype);
     size_t new_size = 0;
-    if (!checked_file_size(header_.n_rows + n, dim, dtype, new_size)) {
+    if (!checked_file_size(header_.n_rows + n, dim, dtype, new_size))
+    {
         err = "storage size overflow";
         return UINT64_MAX;
     }
 
     // Single ftruncate to final size
-    if (!platform::file_truncate(fd_, new_size)) {
+    if (!platform::file_truncate(fd_, new_size))
+    {
         err = std::string("ftruncate: ") + strerror(errno);
         return UINT64_MAX;
     }
@@ -380,36 +493,51 @@ uint64_t VectorStorage::append_batch(const float * data, int n, int dim, std::st
     size_t offset = sizeof(StorageHeader) + header_.n_rows * stride;
 
     // Convert and write based on dtype
-    if (dtype == DTYPE_FLOAT32) {
-        if (file_pwrite(fd_, data, total_bytes, offset) != static_cast<int64_t>(total_bytes)) {
+    if (dtype == DTYPE_FLOAT32)
+    {
+        if (file_pwrite(fd_, data, total_bytes, offset) != static_cast<int64_t>(total_bytes))
+        {
             err = "pwrite batch vec failed";
             return UINT64_MAX;
         }
-    } else if (dtype == DTYPE_FLOAT16) {
+    }
+    else if (dtype == DTYPE_FLOAT16)
+    {
         std::vector<uint16_t> half((size_t)n * dim);
-        for (int i = 0; i < n * dim; ++i) {
+        for (int i = 0; i < n * dim; ++i)
+        {
             half[i] = float32_to_float16(data[i]);
         }
-        if (file_pwrite(fd_, half.data(), total_bytes, offset) != static_cast<int64_t>(total_bytes)) {
+        if (file_pwrite(fd_, half.data(), total_bytes, offset) != static_cast<int64_t>(total_bytes))
+        {
             err = "pwrite batch float16 vec failed";
             return UINT64_MAX;
         }
-    } else if (dtype == DTYPE_INT8) {
+    }
+    else if (dtype == DTYPE_INT8)
+    {
         // Compute max scale across batch
         float max_scale = header_.scale;
-        for (int i = 0; i < n; ++i) {
+        for (int i = 0; i < n; ++i)
+        {
             float vec_scale = compute_int8_scale(data + i * dim, dim);
-            if (vec_scale > max_scale) max_scale = vec_scale;
+            if (vec_scale > max_scale)
+                max_scale = vec_scale;
         }
-        if (max_scale > header_.scale) {
+        if (max_scale > header_.scale)
+        {
             header_.scale = max_scale;
         }
 
         std::vector<int8_t> quantized((size_t)n * dim);
-        for (int i = 0; i < n; ++i) {
-            quantize_float32_to_int8(data + i * dim, quantized.data() + i * dim, dim, header_.scale);
+        for (int i = 0; i < n; ++i)
+        {
+            quantize_float32_to_int8(
+                data + i * dim, quantized.data() + i * dim, dim, header_.scale);
         }
-        if (file_pwrite(fd_, quantized.data(), total_bytes, offset) != static_cast<int64_t>(total_bytes)) {
+        if (file_pwrite(fd_, quantized.data(), total_bytes, offset) !=
+            static_cast<int64_t>(total_bytes))
+        {
             err = "pwrite batch int8 vec failed";
             return UINT64_MAX;
         }
@@ -420,87 +548,119 @@ uint64_t VectorStorage::append_batch(const float * data, int n, int dim, std::st
     file_size_ = new_size;
 
     // Update header once
-    if (file_pwrite(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_))) {
+    if (file_pwrite(fd_, &header_, sizeof(header_), 0) != static_cast<int64_t>(sizeof(header_)))
+    {
         err = "pwrite header failed";
         return UINT64_MAX;
     }
 
     // Extend mapping if needed (single remap at end, or just extend if reserved)
-    if (!extend_mapping_if_needed(err)) return UINT64_MAX;
+    if (!extend_mapping_if_needed(err))
+        return UINT64_MAX;
     return start_id;
 }
 
-size_t VectorStorage::row_stride_bytes() const {
+size_t VectorStorage::row_stride_bytes() const
+{
     return row_stride((int)header_.dim, static_cast<StorageDtype>(header_.dtype));
 }
 
-const void * VectorStorage::row_raw(uint64_t idx) const {
-    if (!map_base_ || idx >= header_.n_rows) return nullptr;
+const void* VectorStorage::row_raw(uint64_t idx) const
+{
+    if (!map_base_ || idx >= header_.n_rows)
+        return nullptr;
     size_t stride = row_stride_bytes();
     if (stride > 0 && idx > (SIZE_MAX - sizeof(StorageHeader)) / stride)
         return nullptr;
     size_t offset = sizeof(StorageHeader) + idx * stride;
-    if (offset + stride > map_size_) return nullptr;
+    if (offset + stride > map_size_)
+        return nullptr;
     return map_base_ + offset;
 }
 
-void VectorStorage::row_to_float32(uint64_t idx, float * out) const {
-    const void * raw = row_raw(idx);
-    if (!raw) return;
+void VectorStorage::row_to_float32(uint64_t idx, float* out) const
+{
+    const void* raw = row_raw(idx);
+    if (!raw)
+        return;
 
     int dim = (int)header_.dim;
     StorageDtype dtype = static_cast<StorageDtype>(header_.dtype);
 
-    if (dtype == DTYPE_FLOAT32) {
+    if (dtype == DTYPE_FLOAT32)
+    {
         std::memcpy(out, raw, dim * sizeof(float));
-    } else if (dtype == DTYPE_FLOAT16) {
-        const uint16_t * half = static_cast<const uint16_t *>(raw);
-        for (int i = 0; i < dim; ++i) {
+    }
+    else if (dtype == DTYPE_FLOAT16)
+    {
+        const uint16_t* half = static_cast<const uint16_t*>(raw);
+        for (int i = 0; i < dim; ++i)
+        {
             out[i] = float16_to_float32(half[i]);
         }
-    } else if (dtype == DTYPE_INT8) {
-        const int8_t * q = static_cast<const int8_t *>(raw);
+    }
+    else if (dtype == DTYPE_INT8)
+    {
+        const int8_t* q = static_cast<const int8_t*>(raw);
         dequantize_int8_to_float32(q, out, dim, header_.scale);
     }
 }
 
-const void * VectorStorage::data_raw() const {
-    if (!map_base_ || header_.n_rows == 0) return nullptr;
+const void* VectorStorage::data_raw() const
+{
+    if (!map_base_ || header_.n_rows == 0)
+        return nullptr;
     return map_base_ + sizeof(StorageHeader);
 }
 
-void VectorStorage::data_to_float32(float * out) const {
-    if (!map_base_ || header_.n_rows == 0) return;
+void VectorStorage::data_to_float32(float* out) const
+{
+    if (!map_base_ || header_.n_rows == 0)
+        return;
 
     int dim = (int)header_.dim;
     StorageDtype dtype = static_cast<StorageDtype>(header_.dtype);
     size_t n = header_.n_rows;
 
-    if (dtype == DTYPE_FLOAT32) {
+    if (dtype == DTYPE_FLOAT32)
+    {
         std::memcpy(out, data_raw(), n * dim * sizeof(float));
-    } else if (dtype == DTYPE_FLOAT16) {
-        const uint16_t * half = static_cast<const uint16_t *>(data_raw());
-        for (size_t i = 0; i < n * dim; ++i) {
+    }
+    else if (dtype == DTYPE_FLOAT16)
+    {
+        const uint16_t* half = static_cast<const uint16_t*>(data_raw());
+        for (size_t i = 0; i < n * dim; ++i)
+        {
             out[i] = float16_to_float32(half[i]);
         }
-    } else if (dtype == DTYPE_INT8) {
-        const int8_t * q = static_cast<const int8_t *>(data_raw());
-        for (size_t i = 0; i < n; ++i) {
+    }
+    else if (dtype == DTYPE_INT8)
+    {
+        const int8_t* q = static_cast<const int8_t*>(data_raw());
+        for (size_t i = 0; i < n; ++i)
+        {
             dequantize_int8_to_float32(q + i * dim, out + i * dim, dim, header_.scale);
         }
     }
 }
 
-bool VectorStorage::sync(std::string & err) {
-    if (fd_ < 0) { err = "not open"; return false; }
-    if (platform::file_sync(fd_) != 0) {
+bool VectorStorage::sync(std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "not open";
+        return false;
+    }
+    if (platform::file_sync(fd_) != 0)
+    {
         err = std::string("fsync: ") + strerror(errno);
         return false;
     }
     return true;
 }
 
-bool VectorStorage::reserve_mapping(size_t min_size, std::string & err) {
+bool VectorStorage::reserve_mapping(size_t min_size, std::string& err)
+{
     unmap();
 
     // Reserve at least DEFAULT_RESERVE_SIZE or min_size, rounded up
@@ -510,30 +670,34 @@ bool VectorStorage::reserve_mapping(size_t min_size, std::string & err) {
 #ifdef _WIN32
     // Windows: use platform mapping
     platform::mmap_close(platform_map_);
-    if (!platform::mmap_reserve(path_, reserved_size_, platform_map_, err)) {
+    if (!platform::mmap_reserve(path_, reserved_size_, platform_map_, err))
+    {
         return false;
     }
     map_base_ = platform_map_.data;
     map_size_ = platform::mmap_commit(platform_map_, file_size_);
 #elif defined(__linux__)
     // Linux: use MAP_NORESERVE to reserve address space without committing memory
-    map_base_ = (uint8_t *)mmap(nullptr, reserved_size_, PROT_READ,
-                                  MAP_SHARED | MAP_NORESERVE, fd_, 0);
-    if (map_base_ == MAP_FAILED) {
+    map_base_ =
+        (uint8_t*)mmap(nullptr, reserved_size_, PROT_READ, MAP_SHARED | MAP_NORESERVE, fd_, 0);
+    if (map_base_ == MAP_FAILED)
+    {
         map_base_ = nullptr;
         err = std::string("mmap reserve: ") + strerror(errno);
         return false;
     }
     // Advise that we don't need the pages beyond current file size yet
-    if (file_size_ < reserved_size_) {
+    if (file_size_ < reserved_size_)
+    {
         madvise(map_base_ + file_size_, reserved_size_ - file_size_, MADV_DONTNEED);
     }
     map_size_ = file_size_;
 #else
     // macOS and others: fall back to regular mmap of current file size
     // We don't reserve extra space on macOS due to lack of MAP_NORESERVE
-    map_base_ = (uint8_t *)mmap(nullptr, file_size_, PROT_READ, MAP_SHARED, fd_, 0);
-    if (map_base_ == MAP_FAILED) {
+    map_base_ = (uint8_t*)mmap(nullptr, file_size_, PROT_READ, MAP_SHARED, fd_, 0);
+    if (map_base_ == MAP_FAILED)
+    {
         map_base_ = nullptr;
         err = std::string("mmap: ") + strerror(errno);
         return false;
@@ -544,12 +708,15 @@ bool VectorStorage::reserve_mapping(size_t min_size, std::string & err) {
     return true;
 }
 
-bool VectorStorage::extend_mapping_if_needed(std::string & err) {
+bool VectorStorage::extend_mapping_if_needed(std::string& err)
+{
     // If file hasn't grown beyond mapped size, nothing to do
-    if (file_size_ <= map_size_) return true;
+    if (file_size_ <= map_size_)
+        return true;
 
     // If we have enough reserved space, just extend the active mapping
-    if (file_size_ <= reserved_size_) {
+    if (file_size_ <= reserved_size_)
+    {
 #ifdef _WIN32
         // Windows: commit more pages
         map_size_ = platform::mmap_commit(platform_map_, file_size_);
@@ -559,7 +726,8 @@ bool VectorStorage::extend_mapping_if_needed(std::string & err) {
         map_size_ = file_size_;
 #else
         // macOS: need to remap since we didn't reserve extra space
-        if (!remap(err)) return false;
+        if (!remap(err))
+            return false;
 #endif
         return true;
     }
@@ -568,19 +736,22 @@ bool VectorStorage::extend_mapping_if_needed(std::string & err) {
     return reserve_mapping(file_size_, err);
 }
 
-bool VectorStorage::remap(std::string & err) {
+bool VectorStorage::remap(std::string& err)
+{
     // Try to use reserve_mapping for better performance
     return reserve_mapping(file_size_, err);
 }
 
-void VectorStorage::unmap() {
+void VectorStorage::unmap()
+{
 #ifdef _WIN32
     platform::mmap_close(platform_map_);
     map_base_ = nullptr;
     map_size_ = 0;
     reserved_size_ = 0;
 #else
-    if (map_base_ && reserved_size_ > 0) {
+    if (map_base_ && reserved_size_ > 0)
+    {
         munmap(map_base_, reserved_size_);
     }
     map_base_ = nullptr;
@@ -589,5 +760,5 @@ void VectorStorage::unmap() {
 #endif
 }
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/src/storage.h
+++ b/src/storage.h
@@ -7,14 +7,17 @@
 #include <string>
 #include <vector>
 
-namespace logosdb {
-namespace internal {
+namespace logosdb
+{
+namespace internal
+{
 
 // Data type for vector storage precision
-enum StorageDtype {
+enum StorageDtype
+{
     DTYPE_FLOAT32 = 0,  // 4 bytes per dimension (default)
     DTYPE_FLOAT16 = 1,  // 2 bytes per dimension
-    DTYPE_INT8    = 2,  // 1 byte per dimension
+    DTYPE_INT8 = 2,     // 1 byte per dimension
 };
 
 // Fixed-stride binary vector storage with mmap support.
@@ -28,14 +31,15 @@ enum StorageDtype {
 //   uint64_t n_rows
 //   float    scale   (for int8 quantization, 1.0 for others)
 
-struct StorageHeader {
-    uint32_t magic    = 0x4C4F474F;
-    uint32_t version  = 2;
-    uint32_t dim      = 0;
-    uint32_t dtype    = 0;        // StorageDtype value
-    uint64_t n_rows   = 0;
-    float    scale    = 1.0f;     // For int8 dequantization
-    float    reserved = 0.0f;     // Padding to 32 bytes
+struct StorageHeader
+{
+    uint32_t magic = 0x4C4F474F;
+    uint32_t version = 2;
+    uint32_t dim = 0;
+    uint32_t dtype = 0;  // StorageDtype value
+    uint64_t n_rows = 0;
+    float scale = 1.0f;     // For int8 dequantization
+    float reserved = 0.0f;  // Padding to 32 bytes
 };
 
 static_assert(sizeof(StorageHeader) == 32, "header must be 32 bytes");
@@ -50,76 +54,78 @@ uint16_t float32_to_float16(float f);
 float float16_to_float32(uint16_t h);
 
 // Quantize float32 array to int8 with given scale
-void quantize_float32_to_int8(const float * src, int8_t * dst, int dim, float scale);
+void quantize_float32_to_int8(const float* src, int8_t* dst, int dim, float scale);
 
 // Dequantize int8 array to float32 with given scale
-void dequantize_int8_to_float32(const int8_t * src, float * dst, int dim, float scale);
+void dequantize_int8_to_float32(const int8_t* src, float* dst, int dim, float scale);
 
 // Compute optimal int8 scale for a vector (max absolute value / 127.0f)
-float compute_int8_scale(const float * vec, int dim);
+float compute_int8_scale(const float* vec, int dim);
 
-class VectorStorage {
-public:
+class VectorStorage
+{
+  public:
     VectorStorage() = default;
     ~VectorStorage();
 
-    VectorStorage(const VectorStorage &) = delete;
-    VectorStorage & operator=(const VectorStorage &) = delete;
+    VectorStorage(const VectorStorage&) = delete;
+    VectorStorage& operator=(const VectorStorage&) = delete;
 
     // Open with explicit dtype (for creating new databases)
-    bool open(const std::string & path, int dim, StorageDtype dtype, std::string & err);
+    bool open(const std::string& path, int dim, StorageDtype dtype, std::string& err);
 
     // Open with default float32 dtype (backward compatibility)
-    bool open(const std::string & path, int dim, std::string & err) {
+    bool open(const std::string& path, int dim, std::string& err)
+    {
         return open(path, dim, DTYPE_FLOAT32, err);
     }
 
     void close();
 
-    uint64_t append(const float * vec, int dim, std::string & err);
+    uint64_t append(const float* vec, int dim, std::string& err);
 
     /* Append n vectors efficiently. Returns the starting id, or UINT64_MAX on error.
      * 'data' must contain n * dim floats. */
-    uint64_t append_batch(const float * data, int n, int dim, std::string & err);
+    uint64_t append_batch(const float* data, int n, int dim, std::string& err);
 
-    size_t      n_rows() const { return header_.n_rows; }
-    int         dim()    const { return (int)header_.dim; }
+    size_t n_rows() const { return header_.n_rows; }
+    int dim() const { return (int)header_.dim; }
     StorageDtype dtype() const { return static_cast<StorageDtype>(header_.dtype); }
 
     // Pointer to the i-th row (valid while file is open/mapped).
     // Note: For reduced precision, this returns a pointer to the raw storage.
     // Use row_to_float32() to get dequantized data.
-    const void * row_raw(uint64_t idx) const;
+    const void* row_raw(uint64_t idx) const;
 
     // Get a row and dequantize to float32 (caller must provide buffer of size dim)
-    void row_to_float32(uint64_t idx, float * out) const;
+    void row_to_float32(uint64_t idx, float* out) const;
 
     // Pointer to the start of all vector data (for bulk tensor load).
     // Note: This is raw storage, not dequantized.
-    const void * data_raw() const;
+    const void* data_raw() const;
 
     // Dequantize all vectors to float32 buffer
-    void data_to_float32(float * out) const;
+    void data_to_float32(float* out) const;
 
-    bool sync(std::string & err);
+    bool sync(std::string& err);
 
-private:
-    bool remap(std::string & err);
+  private:
+    bool remap(std::string& err);
     void unmap();
-    bool reserve_mapping(size_t min_size, std::string & err);
-    bool extend_mapping_if_needed(std::string & err);
+    bool reserve_mapping(size_t min_size, std::string& err);
+    bool extend_mapping_if_needed(std::string& err);
     size_t row_stride_bytes() const;
 
-    std::string    path_;
-    int            fd_        = -1;
-    StorageHeader  header_    = {};
-    uint8_t *      map_base_  = nullptr;
-    size_t         map_size_  = 0;        // Currently mapped size
-    size_t         file_size_ = 0;        // Current file size
-    size_t         reserved_size_ = 0;    // Reserved address space size
+    std::string path_;
+    int fd_ = -1;
+    StorageHeader header_ = {};
+    uint8_t* map_base_ = nullptr;
+    size_t map_size_ = 0;                                       // Currently mapped size
+    size_t file_size_ = 0;                                      // Current file size
+    size_t reserved_size_ = 0;                                  // Reserved address space size
     static constexpr size_t DEFAULT_RESERVE_SIZE = 1ULL << 30;  // 1 GB reservation
-    platform::MappedFile platform_map_{};  // For Windows memory mapping
+    platform::MappedFile platform_map_{};                       // For Windows memory mapping
 };
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -1,31 +1,38 @@
 #include "wal.h"
 
-#include <cerrno>
-#include <cstring>
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include <cerrno>
+#include <cstring>
+
 // For pread/pwrite on older POSIX systems
 #ifndef _WIN32
-    #ifndef _GNU_SOURCE
-        #define _GNU_SOURCE
-    #endif
-    #include <unistd.h>
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <unistd.h>
 #endif
 
 #ifdef _WIN32
-    #include <io.h>
+#include <io.h>
 #endif
 
-namespace logosdb {
-namespace internal {
+namespace logosdb
+{
+namespace internal
+{
 
 static constexpr uint32_t WAL_MAGIC = 0x57474F4C;  // "LOGW" in little-endian
 static constexpr uint32_t WAL_VERSION = 1;
 
-WriteAheadLog::~WriteAheadLog() { close(); }
+WriteAheadLog::~WriteAheadLog()
+{
+    close();
+}
 
-bool WriteAheadLog::open(const std::string & path, std::string & err) {
+bool WriteAheadLog::open(const std::string& path, std::string& err)
+{
     close();
     path_ = path;
 
@@ -35,50 +42,61 @@ bool WriteAheadLog::open(const std::string & path, std::string & err) {
     int flags = O_RDWR | O_CREAT;
 #endif
     fd_ = ::open(path.c_str(), flags, 0644);
-    if (fd_ < 0) {
+    if (fd_ < 0)
+    {
         err = std::string("wal open: ") + strerror(errno);
         return false;
     }
 
     struct stat st;
-    if (fstat(fd_, &st) != 0) {
+    if (fstat(fd_, &st) != 0)
+    {
         err = std::string("wal fstat: ") + strerror(errno);
         close();
         return false;
     }
 
-    if (st.st_size == 0) {
+    if (st.st_size == 0)
+    {
         // New file: write header
         uint32_t header[2] = {WAL_MAGIC, WAL_VERSION};
 #ifdef _WIN32
-        if (_write(fd_, header, sizeof(header)) != sizeof(header)) {
+        if (_write(fd_, header, sizeof(header)) != sizeof(header))
+        {
 #else
-        if (::write(fd_, header, sizeof(header)) != sizeof(header)) {
+        if (::write(fd_, header, sizeof(header)) != sizeof(header))
+        {
 #endif
             err = std::string("wal write header: ") + strerror(errno);
             close();
             return false;
         }
         pending_count_ = 0;
-    } else {
+    }
+    else
+    {
         // Existing file: validate header and count pending entries
         uint32_t header[2];
 #ifdef _WIN32
         if (_lseeki64(fd_, 0, SEEK_SET) != 0 ||
-            _read(fd_, header, sizeof(header)) != sizeof(header)) {
+            _read(fd_, header, sizeof(header)) != sizeof(header))
+        {
 #else
-        if (::pread(fd_, header, sizeof(header), 0) != sizeof(header)) {
+        if (::pread(fd_, header, sizeof(header), 0) != sizeof(header))
+        {
 #endif
             err = std::string("wal read header: ") + strerror(errno);
             close();
             return false;
         }
-        if (header[0] != WAL_MAGIC) {
+        if (header[0] != WAL_MAGIC)
+        {
             err = "wal: bad magic";
             close();
             return false;
         }
-        if (header[1] != WAL_VERSION) {
+        if (header[1] != WAL_VERSION)
+        {
             err = "wal: version mismatch";
             close();
             return false;
@@ -87,22 +105,26 @@ bool WriteAheadLog::open(const std::string & path, std::string & err) {
         // Scan for pending entries
         int64_t offset = sizeof(header);
         WALEntry entry;
-        while (true) {
-            if (!read_entry_at(offset, entry, err)) {
-                if (err.empty()) break;  // EOF
+        while (true)
+        {
+            if (!read_entry_at(offset, entry, err))
+            {
+                if (err.empty())
+                    break;  // EOF
                 close();
                 return false;
             }
-            if (entry.state == WALState::PENDING) {
+            if (entry.state == WALState::PENDING)
+            {
                 ++pending_count_;
             }
             // Calculate next entry offset
-            offset += 1;  // state byte
-            offset += 4;  // dim
+            offset += 1;                                        // state byte
+            offset += 4;                                        // dim
             offset += 4 + entry.vector.size() * sizeof(float);  // vector len + data
-            offset += 4 + entry.text.size();  // text len + data
-            offset += 4 + entry.timestamp.size();  // ts len + data
-            offset += 8;  // expected_id
+            offset += 4 + entry.text.size();                    // text len + data
+            offset += 4 + entry.timestamp.size();               // ts len + data
+            offset += 8;                                        // expected_id
         }
         err.clear();
     }
@@ -110,8 +132,10 @@ bool WriteAheadLog::open(const std::string & path, std::string & err) {
     return true;
 }
 
-void WriteAheadLog::close() {
-    if (fd_ >= 0) {
+void WriteAheadLog::close()
+{
+    if (fd_ >= 0)
+    {
 #ifdef _WIN32
         _close(fd_);
 #else
@@ -123,11 +147,18 @@ void WriteAheadLog::close() {
     pending_count_ = 0;
 }
 
-int64_t WriteAheadLog::append_pending(const float * vec, int dim,
-                                      const char * text, const char * timestamp,
+int64_t WriteAheadLog::append_pending(const float* vec,
+                                      int dim,
+                                      const char* text,
+                                      const char* timestamp,
                                       uint64_t expected_id,
-                                      std::string & err) {
-    if (fd_ < 0) { err = "wal not open"; return -1; }
+                                      std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "wal not open";
+        return -1;
+    }
 
     // Get current file position (where we'll write this entry)
 #ifdef _WIN32
@@ -135,7 +166,8 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
 #else
     off_t offset = ::lseek(fd_, 0, SEEK_END);
 #endif
-    if (offset < 0) {
+    if (offset < 0)
+    {
         err = std::string("wal lseek: ") + strerror(errno);
         return -1;
     }
@@ -143,9 +175,11 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
     // Write state (PENDING)
     uint8_t state = static_cast<uint8_t>(WALState::PENDING);
 #ifdef _WIN32
-    if (_write(fd_, &state, 1) != 1) {
+    if (_write(fd_, &state, 1) != 1)
+    {
 #else
-    if (::write(fd_, &state, 1) != 1) {
+    if (::write(fd_, &state, 1) != 1)
+    {
 #endif
         err = std::string("wal write state: ") + strerror(errno);
         return -1;
@@ -154,9 +188,11 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
     // Write dim
     uint32_t dim_u32 = static_cast<uint32_t>(dim);
 #ifdef _WIN32
-    if (_write(fd_, &dim_u32, 4) != 4) {
+    if (_write(fd_, &dim_u32, 4) != 4)
+    {
 #else
-    if (::write(fd_, &dim_u32, 4) != 4) {
+    if (::write(fd_, &dim_u32, 4) != 4)
+    {
 #endif
         err = std::string("wal write dim: ") + strerror(errno);
         return -1;
@@ -165,17 +201,21 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
     // Write vector length and data
     uint32_t vec_bytes = dim * sizeof(float);
 #ifdef _WIN32
-    if (_write(fd_, &vec_bytes, 4) != 4) {
+    if (_write(fd_, &vec_bytes, 4) != 4)
+    {
         err = std::string("wal write vec len: ") + strerror(errno);
         return -1;
     }
-    if (vec_bytes > 0 && _write(fd_, vec, vec_bytes) != vec_bytes) {
+    if (vec_bytes > 0 && _write(fd_, vec, vec_bytes) != vec_bytes)
+    {
 #else
-    if (::write(fd_, &vec_bytes, 4) != 4) {
+    if (::write(fd_, &vec_bytes, 4) != 4)
+    {
         err = std::string("wal write vec len: ") + strerror(errno);
         return -1;
     }
-    if (vec_bytes > 0 && ::write(fd_, vec, vec_bytes) != vec_bytes) {
+    if (vec_bytes > 0 && ::write(fd_, vec, vec_bytes) != vec_bytes)
+    {
 #endif
         err = std::string("wal write vec data: ") + strerror(errno);
         return -1;
@@ -185,17 +225,21 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
     std::string t = text ? text : "";
     uint32_t text_len = static_cast<uint32_t>(t.size());
 #ifdef _WIN32
-    if (_write(fd_, &text_len, 4) != 4) {
+    if (_write(fd_, &text_len, 4) != 4)
+    {
         err = std::string("wal write text len: ") + strerror(errno);
         return -1;
     }
-    if (text_len > 0 && _write(fd_, t.data(), text_len) != text_len) {
+    if (text_len > 0 && _write(fd_, t.data(), text_len) != text_len)
+    {
 #else
-    if (::write(fd_, &text_len, 4) != 4) {
+    if (::write(fd_, &text_len, 4) != 4)
+    {
         err = std::string("wal write text len: ") + strerror(errno);
         return -1;
     }
-    if (text_len > 0 && ::write(fd_, t.data(), text_len) != text_len) {
+    if (text_len > 0 && ::write(fd_, t.data(), text_len) != text_len)
+    {
 #endif
         err = std::string("wal write text: ") + strerror(errno);
         return -1;
@@ -205,17 +249,21 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
     std::string ts = timestamp ? timestamp : "";
     uint32_t ts_len = static_cast<uint32_t>(ts.size());
 #ifdef _WIN32
-    if (_write(fd_, &ts_len, 4) != 4) {
+    if (_write(fd_, &ts_len, 4) != 4)
+    {
         err = std::string("wal write ts len: ") + strerror(errno);
         return -1;
     }
-    if (ts_len > 0 && _write(fd_, ts.data(), ts_len) != ts_len) {
+    if (ts_len > 0 && _write(fd_, ts.data(), ts_len) != ts_len)
+    {
 #else
-    if (::write(fd_, &ts_len, 4) != 4) {
+    if (::write(fd_, &ts_len, 4) != 4)
+    {
         err = std::string("wal write ts len: ") + strerror(errno);
         return -1;
     }
-    if (ts_len > 0 && ::write(fd_, ts.data(), ts_len) != ts_len) {
+    if (ts_len > 0 && ::write(fd_, ts.data(), ts_len) != ts_len)
+    {
 #endif
         err = std::string("wal write ts: ") + strerror(errno);
         return -1;
@@ -223,16 +271,19 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
 
     // Write expected_id
 #ifdef _WIN32
-    if (_write(fd_, &expected_id, 8) != 8) {
+    if (_write(fd_, &expected_id, 8) != 8)
+    {
 #else
-    if (::write(fd_, &expected_id, 8) != 8) {
+    if (::write(fd_, &expected_id, 8) != 8)
+    {
 #endif
         err = std::string("wal write expected_id: ") + strerror(errno);
         return -1;
     }
 
     // Sync to ensure WAL entry is durable before we modify stores
-    if (!sync(err)) {
+    if (!sync(err))
+    {
         return -1;
     }
 
@@ -240,25 +291,34 @@ int64_t WriteAheadLog::append_pending(const float * vec, int dim,
     return offset;
 }
 
-bool WriteAheadLog::mark_committed(int64_t offset, std::string & err) {
-    if (fd_ < 0) { err = "wal not open"; return false; }
-
-    if (!write_state_at(offset, WALState::COMMITTED, err)) {
+bool WriteAheadLog::mark_committed(int64_t offset, std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "wal not open";
         return false;
     }
 
-    if (pending_count_ > 0) --pending_count_;
+    if (!write_state_at(offset, WALState::COMMITTED, err))
+    {
+        return false;
+    }
+
+    if (pending_count_ > 0)
+        --pending_count_;
     return sync(err);
 }
 
-bool WriteAheadLog::write_state_at(int64_t offset, WALState state, std::string & err) {
+bool WriteAheadLog::write_state_at(int64_t offset, WALState state, std::string& err)
+{
     uint8_t state_byte = static_cast<uint8_t>(state);
 #ifdef _WIN32
     // Windows: seek + write (no pwrite)
-    if (_lseeki64(fd_, offset, SEEK_SET) != offset ||
-        _write(fd_, &state_byte, 1) != 1) {
+    if (_lseeki64(fd_, offset, SEEK_SET) != offset || _write(fd_, &state_byte, 1) != 1)
+    {
 #else
-    if (::pwrite(fd_, &state_byte, 1, offset) != 1) {
+    if (::pwrite(fd_, &state_byte, 1, offset) != 1)
+    {
 #endif
         err = std::string("wal pwrite state: ") + strerror(errno);
         return false;
@@ -266,12 +326,14 @@ bool WriteAheadLog::write_state_at(int64_t offset, WALState state, std::string &
     return true;
 }
 
-bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string & err) {
+bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry& entry, std::string& err)
+{
     err.clear();
 
 #ifdef _WIN32
     // Windows: seek to offset before reading
-    if (_lseeki64(fd_, offset, SEEK_SET) != offset) {
+    if (_lseeki64(fd_, offset, SEEK_SET) != offset)
+    {
         return false;  // EOF or error
     }
 #endif
@@ -279,11 +341,13 @@ bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string 
     // Read state
     uint8_t state_byte;
 #ifdef _WIN32
-    if (_read(fd_, &state_byte, 1) != 1) {
+    if (_read(fd_, &state_byte, 1) != 1)
+    {
         return false;  // EOF or error
     }
 #else
-    if (::pread(fd_, &state_byte, 1, offset) != 1) {
+    if (::pread(fd_, &state_byte, 1, offset) != 1)
+    {
         return false;  // EOF or error
     }
 #endif
@@ -293,9 +357,11 @@ bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string 
     // Read dim
     uint32_t dim;
 #ifdef _WIN32
-    if (_read(fd_, &dim, 4) != 4) {
+    if (_read(fd_, &dim, 4) != 4)
+    {
 #else
-    if (::pread(fd_, &dim, 4, offset) != 4) {
+    if (::pread(fd_, &dim, 4, offset) != 4)
+    {
 #endif
         err = "wal: truncated entry (dim)";
         return false;
@@ -306,25 +372,32 @@ bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string 
     // Read vector
     uint32_t vec_bytes;
 #ifdef _WIN32
-    if (_read(fd_, &vec_bytes, 4) != 4) {
+    if (_read(fd_, &vec_bytes, 4) != 4)
+    {
 #else
-    if (::pread(fd_, &vec_bytes, 4, offset) != 4) {
+    if (::pread(fd_, &vec_bytes, 4, offset) != 4)
+    {
 #endif
         err = "wal: truncated entry (vec len)";
         return false;
     }
     offset += 4;
-    if (vec_bytes > 0) {
+    if (vec_bytes > 0)
+    {
         entry.vector.resize(vec_bytes / sizeof(float));
 #ifdef _WIN32
-        if (_read(fd_, entry.vector.data(), vec_bytes) != vec_bytes) {
+        if (_read(fd_, entry.vector.data(), vec_bytes) != vec_bytes)
+        {
 #else
-        if (::pread(fd_, entry.vector.data(), vec_bytes, offset) != vec_bytes) {
+        if (::pread(fd_, entry.vector.data(), vec_bytes, offset) != vec_bytes)
+        {
 #endif
             err = "wal: truncated entry (vec data)";
             return false;
         }
-    } else {
+    }
+    else
+    {
         entry.vector.clear();
     }
     offset += vec_bytes;
@@ -332,20 +405,25 @@ bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string 
     // Read text
     uint32_t text_len;
 #ifdef _WIN32
-    if (_read(fd_, &text_len, 4) != 4) {
+    if (_read(fd_, &text_len, 4) != 4)
+    {
 #else
-    if (::pread(fd_, &text_len, 4, offset) != 4) {
+    if (::pread(fd_, &text_len, 4, offset) != 4)
+    {
 #endif
         err = "wal: truncated entry (text len)";
         return false;
     }
     offset += 4;
     entry.text.resize(text_len);
-    if (text_len > 0) {
+    if (text_len > 0)
+    {
 #ifdef _WIN32
-        if (_read(fd_, &entry.text[0], text_len) != text_len) {
+        if (_read(fd_, &entry.text[0], text_len) != text_len)
+        {
 #else
-        if (::pread(fd_, &entry.text[0], text_len, offset) != text_len) {
+        if (::pread(fd_, &entry.text[0], text_len, offset) != text_len)
+        {
 #endif
             err = "wal: truncated entry (text data)";
             return false;
@@ -356,20 +434,25 @@ bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string 
     // Read timestamp
     uint32_t ts_len;
 #ifdef _WIN32
-    if (_read(fd_, &ts_len, 4) != 4) {
+    if (_read(fd_, &ts_len, 4) != 4)
+    {
 #else
-    if (::pread(fd_, &ts_len, 4, offset) != 4) {
+    if (::pread(fd_, &ts_len, 4, offset) != 4)
+    {
 #endif
         err = "wal: truncated entry (ts len)";
         return false;
     }
     offset += 4;
     entry.timestamp.resize(ts_len);
-    if (ts_len > 0) {
+    if (ts_len > 0)
+    {
 #ifdef _WIN32
-        if (_read(fd_, &entry.timestamp[0], ts_len) != ts_len) {
+        if (_read(fd_, &entry.timestamp[0], ts_len) != ts_len)
+        {
 #else
-        if (::pread(fd_, &entry.timestamp[0], ts_len, offset) != ts_len) {
+        if (::pread(fd_, &entry.timestamp[0], ts_len, offset) != ts_len)
+        {
 #endif
             err = "wal: truncated entry (ts data)";
             return false;
@@ -379,9 +462,11 @@ bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string 
 
     // Read expected_id
 #ifdef _WIN32
-    if (_read(fd_, &entry.expected_id, 8) != 8) {
+    if (_read(fd_, &entry.expected_id, 8) != 8)
+    {
 #else
-    if (::pread(fd_, &entry.expected_id, 8, offset) != 8) {
+    if (::pread(fd_, &entry.expected_id, 8, offset) != 8)
+    {
 #endif
         err = "wal: truncated entry (expected_id)";
         return false;
@@ -390,69 +475,90 @@ bool WriteAheadLog::read_entry_at(int64_t offset, WALEntry & entry, std::string 
     return true;
 }
 
-int WriteAheadLog::replay_pending(
-    std::function<bool(const WALEntry &, std::string &)> replay_fn,
-    std::string & err) {
-    if (fd_ < 0) { err = "wal not open"; return -1; }
+int WriteAheadLog::replay_pending(std::function<bool(const WALEntry&, std::string&)> replay_fn,
+                                  std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "wal not open";
+        return -1;
+    }
 
     int64_t offset = 8;  // Skip header (magic + version)
     int replayed = 0;
     WALEntry entry;
 
-    while (true) {
+    while (true)
+    {
         // Peek at next entry state
         uint8_t state_byte;
         int64_t r = 0;
 #ifdef _WIN32
         r = _lseeki64(fd_, offset, SEEK_SET);
-        if (r != offset) break;
+        if (r != offset)
+            break;
         r = _read(fd_, &state_byte, 1);
 #else
         r = static_cast<int64_t>(::pread(fd_, &state_byte, 1, offset));
 #endif
-        if (r == 0) break;  // EOF
-        if (r < 0) {
+        if (r == 0)
+            break;  // EOF
+        if (r < 0)
+        {
             err = std::string("wal replay pread: ") + strerror(errno);
             return -1;
         }
 
         // Read full entry
-        if (!read_entry_at(offset, entry, err)) {
-            if (err.empty()) break;
+        if (!read_entry_at(offset, entry, err))
+        {
+            if (err.empty())
+                break;
             return -1;
         }
 
         // Only replay pending entries
-        if (entry.state == WALState::PENDING) {
-            if (!replay_fn(entry, err)) {
+        if (entry.state == WALState::PENDING)
+        {
+            if (!replay_fn(entry, err))
+            {
                 return -1;
             }
             // Mark as committed after successful replay
-            if (!write_state_at(offset, WALState::COMMITTED, err)) {
+            if (!write_state_at(offset, WALState::COMMITTED, err))
+            {
                 return -1;
             }
-            if (pending_count_ > 0) --pending_count_;
+            if (pending_count_ > 0)
+                --pending_count_;
             ++replayed;
         }
 
         // Advance to next entry
-        offset += 1;  // state
-        offset += 4;  // dim
+        offset += 1;                                        // state
+        offset += 4;                                        // dim
         offset += 4 + entry.vector.size() * sizeof(float);  // vector
-        offset += 4 + entry.text.size();  // text
-        offset += 4 + entry.timestamp.size();  // timestamp
-        offset += 8;  // expected_id
+        offset += 4 + entry.text.size();                    // text
+        offset += 4 + entry.timestamp.size();               // timestamp
+        offset += 8;                                        // expected_id
     }
 
     return replayed;
 }
 
-bool WriteAheadLog::sync(std::string & err) {
-    if (fd_ < 0) { err = "wal not open"; return false; }
+bool WriteAheadLog::sync(std::string& err)
+{
+    if (fd_ < 0)
+    {
+        err = "wal not open";
+        return false;
+    }
 #ifdef _WIN32
-    if (_commit(fd_) != 0) {
+    if (_commit(fd_) != 0)
+    {
 #else
-    if (::fsync(fd_) != 0) {
+    if (::fsync(fd_) != 0)
+    {
 #endif
         err = std::string("wal fsync: ") + strerror(errno);
         return false;
@@ -460,5 +566,5 @@ bool WriteAheadLog::sync(std::string & err) {
     return true;
 }
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/src/wal.h
+++ b/src/wal.h
@@ -5,8 +5,10 @@
 #include <string>
 #include <vector>
 
-namespace logosdb {
-namespace internal {
+namespace logosdb
+{
+namespace internal
+{
 
 // Write-Ahead Log for atomic Put operations.
 //
@@ -30,13 +32,15 @@ namespace internal {
 //   [timestamp (ts_len bytes)]
 //   [expected_id uint64 (8 bytes)]
 
-enum class WALState : uint8_t {
+enum class WALState : uint8_t
+{
     PENDING = 0,
     COMMITTED = 1,
     ABORTED = 2
 };
 
-struct WALEntry {
+struct WALEntry
+{
     WALState state = WALState::PENDING;
     uint32_t dim = 0;
     std::vector<float> vector;
@@ -45,49 +49,51 @@ struct WALEntry {
     uint64_t expected_id = 0;  // Expected row id (for validation)
 };
 
-class WriteAheadLog {
-public:
+class WriteAheadLog
+{
+  public:
     WriteAheadLog() = default;
     ~WriteAheadLog();
 
-    WriteAheadLog(const WriteAheadLog &) = delete;
-    WriteAheadLog & operator=(const WriteAheadLog &) = delete;
+    WriteAheadLog(const WriteAheadLog&) = delete;
+    WriteAheadLog& operator=(const WriteAheadLog&) = delete;
 
     // Open or create WAL file at the given path.
-    bool open(const std::string & path, std::string & err);
+    bool open(const std::string& path, std::string& err);
     void close();
 
     // Append a new pending entry. Returns the entry offset in the file
     // (needed to mark committed later), or -1 on error.
-    int64_t append_pending(const float * vec, int dim,
-                           const char * text, const char * timestamp,
+    int64_t append_pending(const float* vec,
+                           int dim,
+                           const char* text,
+                           const char* timestamp,
                            uint64_t expected_id,
-                           std::string & err);
+                           std::string& err);
 
     // Mark an entry as committed by its offset.
-    bool mark_committed(int64_t offset, std::string & err);
+    bool mark_committed(int64_t offset, std::string& err);
 
     // Replay all pending entries, calling the provided function for each.
     // Entries are marked committed after successful replay.
     // Returns number of entries replayed, or -1 on error.
-    int replay_pending(
-        std::function<bool(const WALEntry &, std::string &)> replay_fn,
-        std::string & err);
+    int replay_pending(std::function<bool(const WALEntry&, std::string&)> replay_fn,
+                       std::string& err);
 
     // Sync WAL to disk.
-    bool sync(std::string & err);
+    bool sync(std::string& err);
 
     // Get count of pending entries (for debugging/metrics).
     size_t pending_count() const { return pending_count_; }
 
-private:
-    bool read_entry_at(int64_t offset, WALEntry & entry, std::string & err);
-    bool write_state_at(int64_t offset, WALState state, std::string & err);
+  private:
+    bool read_entry_at(int64_t offset, WALEntry& entry, std::string& err);
+    bool write_state_at(int64_t offset, WALState state, std::string& err);
 
     std::string path_;
     int fd_ = -1;
     size_t pending_count_ = 0;
 };
 
-} // namespace internal
-} // namespace logosdb
+}  // namespace internal
+}  // namespace logosdb

--- a/tests/test_doctest.cpp
+++ b/tests/test_doctest.cpp
@@ -3,6 +3,10 @@
 
 #include <logosdb/logosdb.h>
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -12,34 +16,39 @@
 #include <string>
 #include <vector>
 
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
 using namespace std::string_literals;
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
 
-static std::vector<float> unit_vec(int dim, int seed) {
+static std::vector<float> unit_vec(int dim, int seed)
+{
     std::mt19937 rng(seed);
     std::normal_distribution<float> dist(0.0f, 1.0f);
     std::vector<float> v(dim);
     float norm = 0.0f;
-    for (int i = 0; i < dim; ++i) { v[i] = dist(rng); norm += v[i] * v[i]; }
+    for (int i = 0; i < dim; ++i)
+    {
+        v[i] = dist(rng);
+        norm += v[i] * v[i];
+    }
     norm = std::sqrt(norm);
-    for (int i = 0; i < dim; ++i) v[i] /= norm;
+    for (int i = 0; i < dim; ++i)
+        v[i] /= norm;
     return v;
 }
 
-static int run_cli(const std::string& args, std::string& output) {
+static int run_cli(const std::string& args, std::string& output)
+{
     std::string cmd = "./logosdb-cli " + args + " 2>&1";
     FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return -1;
+    if (!pipe)
+        return -1;
     char buffer[4096];
     output.clear();
-    while (fgets(buffer, sizeof(buffer), pipe)) {
+    while (fgets(buffer, sizeof(buffer), pipe))
+    {
         output += buffer;
     }
     return pclose(pipe);
@@ -49,1514 +58,1637 @@ static int run_cli(const std::string& args, std::string& output) {
 // Test Suite: Core API (storage, db lifecycle)
 // ============================================================================
 
-TEST_SUITE("core") {
-
-TEST_CASE("core: open and close") {
-    std::string path = "/tmp/logosdb_test_oc";
-    std::filesystem::remove_all(path);
-
-    char * err = nullptr;
-    logosdb_options_t * opts = logosdb_options_create();
-    logosdb_options_set_dim(opts, 64);
-    logosdb_t * db = logosdb_open(path.c_str(), opts, &err);
-    logosdb_options_destroy(opts);
-
-    CHECK(db != nullptr);
-    CHECK(err == nullptr);
-    CHECK(logosdb_count(db) == 0);
-    CHECK(logosdb_dim(db) == 64);
-
-    logosdb_close(db);
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: put and search") {
-    std::string path = "/tmp/logosdb_test_ps";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 64});
-
-    auto v0 = unit_vec(64, 100);
-    auto v1 = unit_vec(64, 200);
-    auto v2 = unit_vec(64, 300);
-
-    uint64_t id0 = db.put(v0, "fact zero", "2025-01-01T00:00:00Z");
-    uint64_t id1 = db.put(v1, "fact one",  "2025-02-01T00:00:00Z");
-    uint64_t id2 = db.put(v2, "fact two",  "2025-03-01T00:00:00Z");
-
-    CHECK(id0 == 0);
-    CHECK(id1 == 1);
-    CHECK(id2 == 2);
-    CHECK(db.count() == 3);
-
-    auto hits = db.search(v0, 3);
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == 0);
-    CHECK(hits[0].text == "fact zero");
-    CHECK(hits[0].timestamp == "2025-01-01T00:00:00Z");
-    CHECK(hits[0].score > 0.9f);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: persistence across reopen") {
-    std::string path = "/tmp/logosdb_test_persist";
-    std::filesystem::remove_all(path);
-
-    auto v0 = unit_vec(64, 400);
-    auto v1 = unit_vec(64, 500);
-
+TEST_SUITE("core")
+{
+    TEST_CASE("core: open and close")
     {
-        logosdb::DB db(path, {.dim = 64});
-        db.put(v0, "persisted fact A", "2025-04-01T00:00:00Z");
-        db.put(v1, "persisted fact B", "2025-05-01T00:00:00Z");
-        CHECK(db.count() == 2);
+        std::string path = "/tmp/logosdb_test_oc";
+        std::filesystem::remove_all(path);
+
+        char* err = nullptr;
+        logosdb_options_t* opts = logosdb_options_create();
+        logosdb_options_set_dim(opts, 64);
+        logosdb_t* db = logosdb_open(path.c_str(), opts, &err);
+        logosdb_options_destroy(opts);
+
+        CHECK(db != nullptr);
+        CHECK(err == nullptr);
+        CHECK(logosdb_count(db) == 0);
+        CHECK(logosdb_dim(db) == 64);
+
+        logosdb_close(db);
+        std::filesystem::remove_all(path);
     }
 
+    TEST_CASE("core: put and search")
     {
-        logosdb::DB db(path, {.dim = 64});
-        CHECK(db.count() == 2);
+        std::string path = "/tmp/logosdb_test_ps";
+        std::filesystem::remove_all(path);
 
-        auto hits = db.search(v0, 2);
+        logosdb::DB db(path, {.dim = 64});
+
+        auto v0 = unit_vec(64, 100);
+        auto v1 = unit_vec(64, 200);
+        auto v2 = unit_vec(64, 300);
+
+        uint64_t id0 = db.put(v0, "fact zero", "2025-01-01T00:00:00Z");
+        uint64_t id1 = db.put(v1, "fact one", "2025-02-01T00:00:00Z");
+        uint64_t id2 = db.put(v2, "fact two", "2025-03-01T00:00:00Z");
+
+        CHECK(id0 == 0);
+        CHECK(id1 == 1);
+        CHECK(id2 == 2);
+        CHECK(db.count() == 3);
+
+        auto hits = db.search(v0, 3);
         CHECK(!hits.empty());
         CHECK(hits[0].id == 0);
-        CHECK(hits[0].text == "persisted fact A");
-        CHECK(hits[0].timestamp == "2025-04-01T00:00:00Z");
+        CHECK(hits[0].text == "fact zero");
+        CHECK(hits[0].timestamp == "2025-01-01T00:00:00Z");
+        CHECK(hits[0].score > 0.9f);
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: raw vectors bulk access") {
-    std::string path = "/tmp/logosdb_test_raw";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-    logosdb::DB db(path, {.dim = dim});
-
-    auto v0 = unit_vec(dim, 600);
-    auto v1 = unit_vec(dim, 700);
-    db.put(v0);
-    db.put(v1);
-
-    size_t n_rows = 0;
-    int d = 0;
-    auto raw = db.raw_vectors(n_rows, d);
-    CHECK(!raw.empty());
-    CHECK(n_rows == 2);
-    CHECK(d == dim);
-
-    float diff = 0.0f;
-    for (int i = 0; i < dim; ++i) diff += std::fabs(raw[i] - v0[i]);
-    CHECK(diff < 1e-5f);
-
-    diff = 0.0f;
-    for (int i = 0; i < dim; ++i) diff += std::fabs(raw[dim + i] - v1[i]);
-    CHECK(diff < 1e-5f);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: many vectors self-retrieval") {
-    std::string path = "/tmp/logosdb_test_many";
-    std::filesystem::remove_all(path);
-
-    int dim = 128;
-    int n = 500;
-    logosdb::DB db(path, {.dim = dim, .max_elements = 1000});
-
-    std::vector<std::vector<float>> vecs;
-    for (int i = 0; i < n; ++i) {
-        vecs.push_back(unit_vec(dim, i));
-        db.put(vecs.back(), "row_" + std::to_string(i));
-    }
-    CHECK(db.count() == (size_t)n);
-
-    int self_found = 0;
-    for (int i = 0; i < n; i += 50) {
-        auto hits = db.search(vecs[i], 1);
-        if (!hits.empty() && hits[0].id == (uint64_t)i) ++self_found;
-    }
-    CHECK(self_found == 10);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: search ordering") {
-    std::string path = "/tmp/logosdb_test_order";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim});
-
-    auto base = unit_vec(dim, 1000);
-    auto close_vec = base;
-    close_vec[0] += 0.01f;
-    float norm = 0.0f;
-    for (int i = 0; i < dim; ++i) norm += close_vec[i] * close_vec[i];
-    norm = std::sqrt(norm);
-    for (int i = 0; i < dim; ++i) close_vec[i] /= norm;
-
-    auto far_vec = unit_vec(dim, 2000);
-
-    db.put(far_vec,   "far");
-    db.put(close_vec, "close");
-    db.put(base,      "base");
-
-    auto hits = db.search(base, 3);
-    CHECK(hits.size() == 3);
-    CHECK(hits[0].id == 2);
-    CHECK(hits[1].id == 1);
-    CHECK(hits[0].score >= hits[1].score);
-    CHECK(hits[1].score >= hits[2].score);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: top_k limit and clamping") {
-    std::string path = "/tmp/logosdb_test_topk";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-    logosdb::DB db(path, {.dim = dim});
-
-    for (int i = 0; i < 20; ++i) db.put(unit_vec(dim, i + 3000));
-
-    auto hits1 = db.search(unit_vec(dim, 3000), 1);
-    CHECK(hits1.size() == 1);
-
-    auto hits5 = db.search(unit_vec(dim, 3000), 5);
-    CHECK(hits5.size() == 5);
-
-    auto hits99 = db.search(unit_vec(dim, 3000), 99);
-    CHECK(hits99.size() == 20);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: empty database search") {
-    std::string path = "/tmp/logosdb_test_empty_search";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 32});
-    auto hits = db.search(unit_vec(32, 5000), 5);
-    CHECK(hits.empty());
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: put without metadata") {
-    std::string path = "/tmp/logosdb_test_nometa";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 32});
-    auto v = unit_vec(32, 6000);
-    uint64_t id = db.put(v);
-    CHECK(id == 0);
-
-    auto hits = db.search(v, 1);
-    CHECK(!hits.empty());
-    CHECK(hits[0].text.empty());
-    CHECK(hits[0].timestamp.empty());
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("core: persistence append after reopen") {
-    std::string path = "/tmp/logosdb_test_append_reopen";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-    auto v0 = unit_vec(dim, 1200);
-    auto v1 = unit_vec(dim, 1300);
-    auto v2 = unit_vec(dim, 1400);
-
+    TEST_CASE("core: persistence across reopen")
     {
-        logosdb::DB db(path, {.dim = dim});
-        db.put(v0, "first");
-        CHECK(db.count() == 1);
-    }
-    {
-        logosdb::DB db(path, {.dim = dim});
-        CHECK(db.count() == 1);
-        db.put(v1, "second");
-        db.put(v2, "third");
-        CHECK(db.count() == 3);
-    }
-    {
-        logosdb::DB db(path, {.dim = dim});
-        CHECK(db.count() == 3);
+        std::string path = "/tmp/logosdb_test_persist";
+        std::filesystem::remove_all(path);
 
-        auto hits = db.search(v2, 1);
-        CHECK(!hits.empty());
+        auto v0 = unit_vec(64, 400);
+        auto v1 = unit_vec(64, 500);
+
+        {
+            logosdb::DB db(path, {.dim = 64});
+            db.put(v0, "persisted fact A", "2025-04-01T00:00:00Z");
+            db.put(v1, "persisted fact B", "2025-05-01T00:00:00Z");
+            CHECK(db.count() == 2);
+        }
+
+        {
+            logosdb::DB db(path, {.dim = 64});
+            CHECK(db.count() == 2);
+
+            auto hits = db.search(v0, 2);
+            CHECK(!hits.empty());
+            CHECK(hits[0].id == 0);
+            CHECK(hits[0].text == "persisted fact A");
+            CHECK(hits[0].timestamp == "2025-04-01T00:00:00Z");
+        }
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("core: raw vectors bulk access")
+    {
+        std::string path = "/tmp/logosdb_test_raw";
+        std::filesystem::remove_all(path);
+
+        int dim = 32;
+        logosdb::DB db(path, {.dim = dim});
+
+        auto v0 = unit_vec(dim, 600);
+        auto v1 = unit_vec(dim, 700);
+        db.put(v0);
+        db.put(v1);
+
+        size_t n_rows = 0;
+        int d = 0;
+        auto raw = db.raw_vectors(n_rows, d);
+        CHECK(!raw.empty());
+        CHECK(n_rows == 2);
+        CHECK(d == dim);
+
+        float diff = 0.0f;
+        for (int i = 0; i < dim; ++i)
+            diff += std::fabs(raw[i] - v0[i]);
+        CHECK(diff < 1e-5f);
+
+        diff = 0.0f;
+        for (int i = 0; i < dim; ++i)
+            diff += std::fabs(raw[dim + i] - v1[i]);
+        CHECK(diff < 1e-5f);
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("core: many vectors self-retrieval")
+    {
+        std::string path = "/tmp/logosdb_test_many";
+        std::filesystem::remove_all(path);
+
+        int dim = 128;
+        int n = 500;
+        logosdb::DB db(path, {.dim = dim, .max_elements = 1000});
+
+        std::vector<std::vector<float>> vecs;
+        for (int i = 0; i < n; ++i)
+        {
+            vecs.push_back(unit_vec(dim, i));
+            db.put(vecs.back(), "row_" + std::to_string(i));
+        }
+        CHECK(db.count() == (size_t)n);
+
+        int self_found = 0;
+        for (int i = 0; i < n; i += 50)
+        {
+            auto hits = db.search(vecs[i], 1);
+            if (!hits.empty() && hits[0].id == (uint64_t)i)
+                ++self_found;
+        }
+        CHECK(self_found == 10);
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("core: search ordering")
+    {
+        std::string path = "/tmp/logosdb_test_order";
+        std::filesystem::remove_all(path);
+
+        int dim = 64;
+        logosdb::DB db(path, {.dim = dim});
+
+        auto base = unit_vec(dim, 1000);
+        auto close_vec = base;
+        close_vec[0] += 0.01f;
+        float norm = 0.0f;
+        for (int i = 0; i < dim; ++i)
+            norm += close_vec[i] * close_vec[i];
+        norm = std::sqrt(norm);
+        for (int i = 0; i < dim; ++i)
+            close_vec[i] /= norm;
+
+        auto far_vec = unit_vec(dim, 2000);
+
+        db.put(far_vec, "far");
+        db.put(close_vec, "close");
+        db.put(base, "base");
+
+        auto hits = db.search(base, 3);
+        CHECK(hits.size() == 3);
         CHECK(hits[0].id == 2);
-        CHECK(hits[0].text == "third");
+        CHECK(hits[1].id == 1);
+        CHECK(hits[0].score >= hits[1].score);
+        CHECK(hits[1].score >= hits[2].score);
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
+    TEST_CASE("core: top_k limit and clamping")
+    {
+        std::string path = "/tmp/logosdb_test_topk";
+        std::filesystem::remove_all(path);
 
-TEST_CASE("core: large dimension (2048)") {
-    std::string path = "/tmp/logosdb_test_largedim";
-    std::filesystem::remove_all(path);
+        int dim = 32;
+        logosdb::DB db(path, {.dim = dim});
 
-    int dim = 2048;
-    logosdb::DB db(path, {.dim = dim});
+        for (int i = 0; i < 20; ++i)
+            db.put(unit_vec(dim, i + 3000));
 
-    auto v0 = unit_vec(dim, 1600);
-    auto v1 = unit_vec(dim, 1700);
-    db.put(v0, "large dim A");
-    db.put(v1, "large dim B");
+        auto hits1 = db.search(unit_vec(dim, 3000), 1);
+        CHECK(hits1.size() == 1);
 
-    CHECK(db.count() == 2);
+        auto hits5 = db.search(unit_vec(dim, 3000), 5);
+        CHECK(hits5.size() == 5);
 
-    auto hits = db.search(v0, 1);
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == 0);
-    CHECK(hits[0].text == "large dim A");
+        auto hits99 = db.search(unit_vec(dim, 3000), 99);
+        CHECK(hits99.size() == 20);
 
-    std::filesystem::remove_all(path);
-}
+        std::filesystem::remove_all(path);
+    }
 
-} // TEST_SUITE("core")
+    TEST_CASE("core: empty database search")
+    {
+        std::string path = "/tmp/logosdb_test_empty_search";
+        std::filesystem::remove_all(path);
+
+        logosdb::DB db(path, {.dim = 32});
+        auto hits = db.search(unit_vec(32, 5000), 5);
+        CHECK(hits.empty());
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("core: put without metadata")
+    {
+        std::string path = "/tmp/logosdb_test_nometa";
+        std::filesystem::remove_all(path);
+
+        logosdb::DB db(path, {.dim = 32});
+        auto v = unit_vec(32, 6000);
+        uint64_t id = db.put(v);
+        CHECK(id == 0);
+
+        auto hits = db.search(v, 1);
+        CHECK(!hits.empty());
+        CHECK(hits[0].text.empty());
+        CHECK(hits[0].timestamp.empty());
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("core: persistence append after reopen")
+    {
+        std::string path = "/tmp/logosdb_test_append_reopen";
+        std::filesystem::remove_all(path);
+
+        int dim = 32;
+        auto v0 = unit_vec(dim, 1200);
+        auto v1 = unit_vec(dim, 1300);
+        auto v2 = unit_vec(dim, 1400);
+
+        {
+            logosdb::DB db(path, {.dim = dim});
+            db.put(v0, "first");
+            CHECK(db.count() == 1);
+        }
+        {
+            logosdb::DB db(path, {.dim = dim});
+            CHECK(db.count() == 1);
+            db.put(v1, "second");
+            db.put(v2, "third");
+            CHECK(db.count() == 3);
+        }
+        {
+            logosdb::DB db(path, {.dim = dim});
+            CHECK(db.count() == 3);
+
+            auto hits = db.search(v2, 1);
+            CHECK(!hits.empty());
+            CHECK(hits[0].id == 2);
+            CHECK(hits[0].text == "third");
+        }
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("core: large dimension (2048)")
+    {
+        std::string path = "/tmp/logosdb_test_largedim";
+        std::filesystem::remove_all(path);
+
+        int dim = 2048;
+        logosdb::DB db(path, {.dim = dim});
+
+        auto v0 = unit_vec(dim, 1600);
+        auto v1 = unit_vec(dim, 1700);
+        db.put(v0, "large dim A");
+        db.put(v1, "large dim B");
+
+        CHECK(db.count() == 2);
+
+        auto hits = db.search(v0, 1);
+        CHECK(!hits.empty());
+        CHECK(hits[0].id == 0);
+        CHECK(hits[0].text == "large dim A");
+
+        std::filesystem::remove_all(path);
+    }
+
+}  // TEST_SUITE("core")
 
 // ============================================================================
 // Test Suite: Metadata
 // ============================================================================
 
-TEST_SUITE("metadata") {
-
-TEST_CASE("metadata: special characters round-trip") {
-    std::string path = "/tmp/logosdb_test_special";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 32});
-    auto v = unit_vec(32, 7000);
-
-    std::string special = "He said \"hello\"\nand\ttabs\\backslash";
-    db.put(v, special, "2025-06-25T00:00:00Z");
-
-    { logosdb::DB db2(path, {.dim = 32});
-      auto hits = db2.search(v, 1);
-      CHECK(!hits.empty());
-      CHECK(hits[0].text == special);
-    }
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("metadata: unicode and escapes") {
-    std::string path = "/tmp/logosdb_test_unicode";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 32});
-    auto v0 = unit_vec(32, 4000);
-    auto v1 = unit_vec(32, 4100);
-    auto v2 = unit_vec(32, 4200);
-
-    std::string unicode = "Hello \u4e16\u754c \u00e9\u00e0";
-    db.put(v0, unicode, "2025-01-01T00:00:00Z");
-    db.put(v1, "", "");
-
-    std::string complex_escapes = "Path: C:\\Users\\test\\file.txt\\\"quoted\"";
-    db.put(v2, complex_escapes);
-
-    { logosdb::DB db2(path, {.dim = 32});
-      auto hits0 = db2.search(v0, 1);
-      CHECK(!hits0.empty());
-      CHECK(hits0[0].text == unicode);
-
-      auto hits1 = db2.search(v1, 1);
-      CHECK(!hits1.empty());
-      CHECK(hits1[0].text == "");
-      CHECK(hits1[0].timestamp == "");
-
-      auto hits2 = db2.search(v2, 1);
-      CHECK(!hits2.empty());
-      CHECK(hits2[0].text == complex_escapes);
-    }
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("metadata: JSON edge cases") {
-    std::string path = "/tmp/logosdb_test_jsonedge";
-    std::filesystem::remove_all(path);
-
+TEST_SUITE("metadata")
+{
+    TEST_CASE("metadata: special characters round-trip")
     {
+        std::string path = "/tmp/logosdb_test_special";
+        std::filesystem::remove_all(path);
+
         logosdb::DB db(path, {.dim = 32});
-        auto v0 = unit_vec(32, 6000);
-        auto v1 = unit_vec(32, 6100);
-        auto v2 = unit_vec(32, 6200);
-        db.put(v0, "unicode: \u4e16\u754c", "2025-01-01T00:00:00Z");
-        db.put(v1, "spaced text", "2025-02-02T12:00:00Z");
-        db.put(v2, "https://example.com/path", "2025-03-03T00:00:00Z");
-        CHECK(db.count() == 3);
+        auto v = unit_vec(32, 7000);
+
+        std::string special = "He said \"hello\"\nand\ttabs\\backslash";
+        db.put(v, special, "2025-06-25T00:00:00Z");
+
+        {
+            logosdb::DB db2(path, {.dim = 32});
+            auto hits = db2.search(v, 1);
+            CHECK(!hits.empty());
+            CHECK(hits[0].text == special);
+        }
+
+        std::filesystem::remove_all(path);
     }
 
+    TEST_CASE("metadata: unicode and escapes")
     {
+        std::string path = "/tmp/logosdb_test_unicode";
+        std::filesystem::remove_all(path);
+
         logosdb::DB db(path, {.dim = 32});
-        CHECK(db.count() == 3);
+        auto v0 = unit_vec(32, 4000);
+        auto v1 = unit_vec(32, 4100);
+        auto v2 = unit_vec(32, 4200);
 
-        auto v0 = unit_vec(32, 6000);
-        auto v1 = unit_vec(32, 6100);
-        auto v2 = unit_vec(32, 6200);
+        std::string unicode = "Hello \u4e16\u754c \u00e9\u00e0";
+        db.put(v0, unicode, "2025-01-01T00:00:00Z");
+        db.put(v1, "", "");
 
-        auto hits0 = db.search(v0, 1);
-        CHECK(!hits0.empty());
-        CHECK(hits0[0].text == "unicode: \u4e16\u754c");
+        std::string complex_escapes = "Path: C:\\Users\\test\\file.txt\\\"quoted\"";
+        db.put(v2, complex_escapes);
 
-        auto hits1 = db.search(v1, 1);
-        CHECK(!hits1.empty());
-        CHECK(hits1[0].text == "spaced text");
+        {
+            logosdb::DB db2(path, {.dim = 32});
+            auto hits0 = db2.search(v0, 1);
+            CHECK(!hits0.empty());
+            CHECK(hits0[0].text == unicode);
 
-        auto hits2 = db.search(v2, 1);
-        CHECK(!hits2.empty());
-        CHECK(hits2[0].text == "https://example.com/path");
+            auto hits1 = db2.search(v1, 1);
+            CHECK(!hits1.empty());
+            CHECK(hits1[0].text == "");
+            CHECK(hits1[0].timestamp == "");
+
+            auto hits2 = db2.search(v2, 1);
+            CHECK(!hits2.empty());
+            CHECK(hits2[0].text == complex_escapes);
+        }
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
+    TEST_CASE("metadata: JSON edge cases")
+    {
+        std::string path = "/tmp/logosdb_test_jsonedge";
+        std::filesystem::remove_all(path);
 
-} // TEST_SUITE("metadata")
+        {
+            logosdb::DB db(path, {.dim = 32});
+            auto v0 = unit_vec(32, 6000);
+            auto v1 = unit_vec(32, 6100);
+            auto v2 = unit_vec(32, 6200);
+            db.put(v0, "unicode: \u4e16\u754c", "2025-01-01T00:00:00Z");
+            db.put(v1, "spaced text", "2025-02-02T12:00:00Z");
+            db.put(v2, "https://example.com/path", "2025-03-03T00:00:00Z");
+            CHECK(db.count() == 3);
+        }
+
+        {
+            logosdb::DB db(path, {.dim = 32});
+            CHECK(db.count() == 3);
+
+            auto v0 = unit_vec(32, 6000);
+            auto v1 = unit_vec(32, 6100);
+            auto v2 = unit_vec(32, 6200);
+
+            auto hits0 = db.search(v0, 1);
+            CHECK(!hits0.empty());
+            CHECK(hits0[0].text == "unicode: \u4e16\u754c");
+
+            auto hits1 = db.search(v1, 1);
+            CHECK(!hits1.empty());
+            CHECK(hits1[0].text == "spaced text");
+
+            auto hits2 = db.search(v2, 1);
+            CHECK(!hits2.empty());
+            CHECK(hits2[0].text == "https://example.com/path");
+        }
+
+        std::filesystem::remove_all(path);
+    }
+
+}  // TEST_SUITE("metadata")
 
 // ============================================================================
 // Test Suite: Error Handling
 // ============================================================================
 
-TEST_SUITE("errors") {
+TEST_SUITE("errors")
+{
+    TEST_CASE("errors: C API error handling")
+    {
+        char* err = nullptr;
 
-TEST_CASE("errors: C API error handling") {
-    char * err = nullptr;
+        logosdb_options_t* opts = logosdb_options_create();
+        logosdb_options_set_dim(opts, 0);
+        logosdb_t* db = logosdb_open("/tmp/logosdb_test_err", opts, &err);
+        CHECK(db == nullptr);
+        CHECK(err != nullptr);
+        free(err);
+        err = nullptr;
+        logosdb_options_destroy(opts);
 
-    logosdb_options_t * opts = logosdb_options_create();
-    logosdb_options_set_dim(opts, 0);
-    logosdb_t * db = logosdb_open("/tmp/logosdb_test_err", opts, &err);
-    CHECK(db == nullptr);
-    CHECK(err != nullptr);
-    free(err); err = nullptr;
-    logosdb_options_destroy(opts);
+        CHECK(logosdb_count(nullptr) == 0);
+        CHECK(logosdb_dim(nullptr) == 0);
 
-    CHECK(logosdb_count(nullptr) == 0);
-    CHECK(logosdb_dim(nullptr) == 0);
-
-    logosdb_search_result_t * r = logosdb_search(nullptr, nullptr, 0, 1, &err);
-    CHECK(r == nullptr);
-    free(err);
-}
-
-TEST_CASE("errors: C++ wrapper exception") {
-    bool caught = false;
-    try {
-        logosdb::DB db("/tmp/logosdb_test_exc", {.dim = 0});
-    } catch (const std::runtime_error & e) {
-        caught = true;
-        CHECK(std::string(e.what()).find("logosdb_open") != std::string::npos);
+        logosdb_search_result_t* r = logosdb_search(nullptr, nullptr, 0, 1, &err);
+        CHECK(r == nullptr);
+        free(err);
     }
-    CHECK(caught);
-}
 
-TEST_CASE("errors: dimension mismatch on put") {
-    std::string path = "/tmp/logosdb_test_dim_put";
-    std::filesystem::remove_all(path);
+    TEST_CASE("errors: C++ wrapper exception")
+    {
+        bool caught = false;
+        try
+        {
+            logosdb::DB db("/tmp/logosdb_test_exc", {.dim = 0});
+        }
+        catch (const std::runtime_error& e)
+        {
+            caught = true;
+            CHECK(std::string(e.what()).find("logosdb_open") != std::string::npos);
+        }
+        CHECK(caught);
+    }
 
-    char * err = nullptr;
-    logosdb_options_t * opts = logosdb_options_create();
-    logosdb_options_set_dim(opts, 32);
-    logosdb_t * db = logosdb_open(path.c_str(), opts, &err);
-    logosdb_options_destroy(opts);
-    CHECK(db != nullptr);
+    TEST_CASE("errors: dimension mismatch on put")
+    {
+        std::string path = "/tmp/logosdb_test_dim_put";
+        std::filesystem::remove_all(path);
 
-    auto wrong = unit_vec(64, 8000);
-    uint64_t id = logosdb_put(db, wrong.data(), 64, "bad", nullptr, &err);
-    CHECK(id == UINT64_MAX);
-    CHECK(err != nullptr);
-    free(err); err = nullptr;
+        char* err = nullptr;
+        logosdb_options_t* opts = logosdb_options_create();
+        logosdb_options_set_dim(opts, 32);
+        logosdb_t* db = logosdb_open(path.c_str(), opts, &err);
+        logosdb_options_destroy(opts);
+        CHECK(db != nullptr);
 
-    CHECK(logosdb_count(db) == 0);
-    logosdb_close(db);
-    std::filesystem::remove_all(path);
-}
+        auto wrong = unit_vec(64, 8000);
+        uint64_t id = logosdb_put(db, wrong.data(), 64, "bad", nullptr, &err);
+        CHECK(id == UINT64_MAX);
+        CHECK(err != nullptr);
+        free(err);
+        err = nullptr;
 
-TEST_CASE("errors: dimension mismatch on search") {
-    std::string path = "/tmp/logosdb_test_dim_search";
-    std::filesystem::remove_all(path);
+        CHECK(logosdb_count(db) == 0);
+        logosdb_close(db);
+        std::filesystem::remove_all(path);
+    }
 
-    char * err = nullptr;
-    logosdb_options_t * opts = logosdb_options_create();
-    logosdb_options_set_dim(opts, 32);
-    logosdb_t * db = logosdb_open(path.c_str(), opts, &err);
-    logosdb_options_destroy(opts);
+    TEST_CASE("errors: dimension mismatch on search")
+    {
+        std::string path = "/tmp/logosdb_test_dim_search";
+        std::filesystem::remove_all(path);
 
-    auto v = unit_vec(32, 9000);
-    logosdb_put(db, v.data(), 32, "ok", nullptr, &err);
+        char* err = nullptr;
+        logosdb_options_t* opts = logosdb_options_create();
+        logosdb_options_set_dim(opts, 32);
+        logosdb_t* db = logosdb_open(path.c_str(), opts, &err);
+        logosdb_options_destroy(opts);
 
-    auto wrong_q = unit_vec(64, 9001);
-    logosdb_search_result_t * r = logosdb_search(db, wrong_q.data(), 64, 1, &err);
-    CHECK(r == nullptr);
-    CHECK(err != nullptr);
-    free(err);
+        auto v = unit_vec(32, 9000);
+        logosdb_put(db, v.data(), 32, "ok", nullptr, &err);
 
-    logosdb_close(db);
-    std::filesystem::remove_all(path);
-}
+        auto wrong_q = unit_vec(64, 9001);
+        logosdb_search_result_t* r = logosdb_search(db, wrong_q.data(), 64, 1, &err);
+        CHECK(r == nullptr);
+        CHECK(err != nullptr);
+        free(err);
 
-TEST_CASE("errors: result accessor bounds") {
-    std::string path = "/tmp/logosdb_test_bounds";
-    std::filesystem::remove_all(path);
+        logosdb_close(db);
+        std::filesystem::remove_all(path);
+    }
 
-    char * err = nullptr;
-    logosdb_options_t * opts = logosdb_options_create();
-    logosdb_options_set_dim(opts, 32);
-    logosdb_t * db = logosdb_open(path.c_str(), opts, &err);
-    logosdb_options_destroy(opts);
+    TEST_CASE("errors: result accessor bounds")
+    {
+        std::string path = "/tmp/logosdb_test_bounds";
+        std::filesystem::remove_all(path);
 
-    auto v = unit_vec(32, 1100);
-    logosdb_put(db, v.data(), 32, "x", nullptr, &err);
+        char* err = nullptr;
+        logosdb_options_t* opts = logosdb_options_create();
+        logosdb_options_set_dim(opts, 32);
+        logosdb_t* db = logosdb_open(path.c_str(), opts, &err);
+        logosdb_options_destroy(opts);
 
-    logosdb_search_result_t * r = logosdb_search(db, v.data(), 32, 1, &err);
-    CHECK(r != nullptr);
-    CHECK(logosdb_result_count(r) == 1);
+        auto v = unit_vec(32, 1100);
+        logosdb_put(db, v.data(), 32, "x", nullptr, &err);
 
-    CHECK(logosdb_result_id(r, -1) == UINT64_MAX);
-    CHECK(logosdb_result_id(r, 5) == UINT64_MAX);
-    CHECK(logosdb_result_text(r, -1) == nullptr);
-    CHECK(logosdb_result_text(r, 5) == nullptr);
-    CHECK(logosdb_result_score(r, 99) == 0.0f);
-    CHECK(logosdb_result_timestamp(r, -1) == nullptr);
+        logosdb_search_result_t* r = logosdb_search(db, v.data(), 32, 1, &err);
+        CHECK(r != nullptr);
+        CHECK(logosdb_result_count(r) == 1);
 
-    CHECK(logosdb_result_count(nullptr) == 0);
+        CHECK(logosdb_result_id(r, -1) == UINT64_MAX);
+        CHECK(logosdb_result_id(r, 5) == UINT64_MAX);
+        CHECK(logosdb_result_text(r, -1) == nullptr);
+        CHECK(logosdb_result_text(r, 5) == nullptr);
+        CHECK(logosdb_result_score(r, 99) == 0.0f);
+        CHECK(logosdb_result_timestamp(r, -1) == nullptr);
 
-    logosdb_result_free(r);
-    logosdb_close(db);
-    std::filesystem::remove_all(path);
-}
+        CHECK(logosdb_result_count(nullptr) == 0);
 
-} // TEST_SUITE("errors")
+        logosdb_result_free(r);
+        logosdb_close(db);
+        std::filesystem::remove_all(path);
+    }
+
+}  // TEST_SUITE("errors")
 
 // ============================================================================
 // Test Suite: Delete and Update
 // ============================================================================
 
-TEST_SUITE("delete_update") {
-
-TEST_CASE("delete_update: basic delete") {
-    std::string path = "/tmp/logosdb_test_delete_basic";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim});
-
-    auto v0 = unit_vec(dim, 2100);
-    auto v1 = unit_vec(dim, 2200);
-    auto v2 = unit_vec(dim, 2300);
-
-    db.put(v0, "zero");
-    db.put(v1, "one");
-    db.put(v2, "two");
-    CHECK(db.count() == 3);
-    CHECK(db.count_live() == 3);
-
-    db.del(1);
-    CHECK(db.count() == 3);
-    CHECK(db.count_live() == 2);
-
-    auto hits = db.search(v1, 3);
-    bool found = false;
-    for (auto & h : hits) if (h.id == 1) found = true;
-    CHECK(!found);
-
-    auto self_hits = db.search(v0, 1);
-    CHECK(!self_hits.empty());
-    CHECK(self_hits[0].id == 0);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("delete_update: delete errors") {
-    std::string path = "/tmp/logosdb_test_delete_err";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 32});
-    auto v0 = unit_vec(32, 2400);
-    db.put(v0, "only");
-
-    char * err = nullptr;
-    int rc = logosdb_delete(db.handle(), 99, &err);
-    CHECK(rc == -1);
-    CHECK(err != nullptr);
-    free(err); err = nullptr;
-
-    rc = logosdb_delete(db.handle(), 0, &err);
-    CHECK(rc == 0);
-    CHECK(err == nullptr);
-
-    rc = logosdb_delete(db.handle(), 0, &err);
-    CHECK(rc == -1);
-    CHECK(err != nullptr);
-    free(err);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("delete_update: delete persistence") {
-    std::string path = "/tmp/logosdb_test_delete_persist";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-    auto v0 = unit_vec(dim, 2500);
-    auto v1 = unit_vec(dim, 2600);
-    auto v2 = unit_vec(dim, 2700);
-
+TEST_SUITE("delete_update")
+{
+    TEST_CASE("delete_update: basic delete")
     {
+        std::string path = "/tmp/logosdb_test_delete_basic";
+        std::filesystem::remove_all(path);
+
+        int dim = 64;
         logosdb::DB db(path, {.dim = dim});
-        db.put(v0, "a");
-        db.put(v1, "b");
-        db.put(v2, "c");
+
+        auto v0 = unit_vec(dim, 2100);
+        auto v1 = unit_vec(dim, 2200);
+        auto v2 = unit_vec(dim, 2300);
+
+        db.put(v0, "zero");
+        db.put(v1, "one");
+        db.put(v2, "two");
+        CHECK(db.count() == 3);
+        CHECK(db.count_live() == 3);
+
         db.del(1);
-        CHECK(db.count_live() == 2);
-    }
-    {
-        logosdb::DB db(path, {.dim = dim});
         CHECK(db.count() == 3);
         CHECK(db.count_live() == 2);
 
         auto hits = db.search(v1, 3);
         bool found = false;
-        for (auto & h : hits) if (h.id == 1) found = true;
+        for (auto& h : hits)
+            if (h.id == 1)
+                found = true;
         CHECK(!found);
 
-        auto hits_a = db.search(v0, 1);
-        CHECK(!hits_a.empty());
-        CHECK(hits_a[0].id == 0);
+        auto self_hits = db.search(v0, 1);
+        CHECK(!self_hits.empty());
+        CHECK(self_hits[0].id == 0);
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("delete_update: tombstone replay on index rebuild") {
-    std::string path = "/tmp/logosdb_test_delete_rebuild";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-    auto v0 = unit_vec(dim, 2800);
-    auto v1 = unit_vec(dim, 2900);
-
+    TEST_CASE("delete_update: delete errors")
     {
-        logosdb::DB db(path, {.dim = dim});
-        db.put(v0, "alpha");
-        db.put(v1, "beta");
-        db.del(0);
+        std::string path = "/tmp/logosdb_test_delete_err";
+        std::filesystem::remove_all(path);
+
+        logosdb::DB db(path, {.dim = 32});
+        auto v0 = unit_vec(32, 2400);
+        db.put(v0, "only");
+
+        char* err = nullptr;
+        int rc = logosdb_delete(db.handle(), 99, &err);
+        CHECK(rc == -1);
+        CHECK(err != nullptr);
+        free(err);
+        err = nullptr;
+
+        rc = logosdb_delete(db.handle(), 0, &err);
+        CHECK(rc == 0);
+        CHECK(err == nullptr);
+
+        rc = logosdb_delete(db.handle(), 0, &err);
+        CHECK(rc == -1);
+        CHECK(err != nullptr);
+        free(err);
+
+        std::filesystem::remove_all(path);
     }
 
-    std::error_code ec;
-    std::filesystem::remove(path + "/hnsw.idx", ec);
-    CHECK(!ec);
-
+    TEST_CASE("delete_update: delete persistence")
     {
+        std::string path = "/tmp/logosdb_test_delete_persist";
+        std::filesystem::remove_all(path);
+
+        int dim = 32;
+        auto v0 = unit_vec(dim, 2500);
+        auto v1 = unit_vec(dim, 2600);
+        auto v2 = unit_vec(dim, 2700);
+
+        {
+            logosdb::DB db(path, {.dim = dim});
+            db.put(v0, "a");
+            db.put(v1, "b");
+            db.put(v2, "c");
+            db.del(1);
+            CHECK(db.count_live() == 2);
+        }
+        {
+            logosdb::DB db(path, {.dim = dim});
+            CHECK(db.count() == 3);
+            CHECK(db.count_live() == 2);
+
+            auto hits = db.search(v1, 3);
+            bool found = false;
+            for (auto& h : hits)
+                if (h.id == 1)
+                    found = true;
+            CHECK(!found);
+
+            auto hits_a = db.search(v0, 1);
+            CHECK(!hits_a.empty());
+            CHECK(hits_a[0].id == 0);
+        }
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("delete_update: tombstone replay on index rebuild")
+    {
+        std::string path = "/tmp/logosdb_test_delete_rebuild";
+        std::filesystem::remove_all(path);
+
+        int dim = 32;
+        auto v0 = unit_vec(dim, 2800);
+        auto v1 = unit_vec(dim, 2900);
+
+        {
+            logosdb::DB db(path, {.dim = dim});
+            db.put(v0, "alpha");
+            db.put(v1, "beta");
+            db.del(0);
+        }
+
+        std::error_code ec;
+        std::filesystem::remove(path + "/hnsw.idx", ec);
+        CHECK(!ec);
+
+        {
+            logosdb::DB db(path, {.dim = dim});
+            CHECK(db.count_live() == 1);
+
+            auto hits = db.search(v0, 2);
+            bool found = false;
+            for (auto& h : hits)
+                if (h.id == 0)
+                    found = true;
+            CHECK(!found);
+        }
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("delete_update: basic update")
+    {
+        std::string path = "/tmp/logosdb_test_update";
+        std::filesystem::remove_all(path);
+
+        int dim = 64;
         logosdb::DB db(path, {.dim = dim});
+
+        auto v0 = unit_vec(dim, 3100);
+        auto v1 = unit_vec(dim, 3200);
+        auto v_new = unit_vec(dim, 3300);
+
+        db.put(v0, "old zero");
+        db.put(v1, "keep one");
+        CHECK(db.count_live() == 2);
+
+        uint64_t new_id = db.update(0, v_new, "new zero", "2025-07-01T00:00:00Z");
+        CHECK(new_id == 2);
+        CHECK(db.count() == 3);
+        CHECK(db.count_live() == 2);
+
+        auto hits_new = db.search(v_new, 1);
+        CHECK(!hits_new.empty());
+        CHECK(hits_new[0].id == new_id);
+        CHECK(hits_new[0].text == "new zero");
+        CHECK(hits_new[0].timestamp == "2025-07-01T00:00:00Z");
+
+        auto hits_old = db.search(v0, 3);
+        bool old_found = false;
+        for (auto& h : hits_old)
+            if (h.id == 0)
+                old_found = true;
+        CHECK(!old_found);
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("delete_update: update errors")
+    {
+        std::string path = "/tmp/logosdb_test_update_err";
+        std::filesystem::remove_all(path);
+
+        logosdb::DB db(path, {.dim = 32});
+        auto v0 = unit_vec(32, 3400);
+        auto v1 = unit_vec(32, 3500);
+        db.put(v0, "a");
+
+        char* err = nullptr;
+        uint64_t r = logosdb_update(db.handle(), 99, v1.data(), 32, "x", nullptr, &err);
+        CHECK(r == UINT64_MAX);
+        CHECK(err != nullptr);
+        free(err);
+        err = nullptr;
+
+        auto wrong = unit_vec(16, 3600);
+        r = logosdb_update(db.handle(), 0, wrong.data(), 16, "x", nullptr, &err);
+        CHECK(r == UINT64_MAX);
+        CHECK(err != nullptr);
+        free(err);
+        err = nullptr;
+
+        logosdb_delete(db.handle(), 0, &err);
+        free(err);
+        err = nullptr;
+        r = logosdb_update(db.handle(), 0, v1.data(), 32, "x", nullptr, &err);
+        CHECK(r == UINT64_MAX);
+        CHECK(err != nullptr);
+        free(err);
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("delete_update: delete and reput independence")
+    {
+        std::string path = "/tmp/logosdb_test_delete_reput";
+        std::filesystem::remove_all(path);
+
+        int dim = 32;
+        logosdb::DB db(path, {.dim = dim});
+
+        auto v0 = unit_vec(dim, 3700);
+        auto v1 = unit_vec(dim, 3800);
+
+        uint64_t id0 = db.put(v0, "first");
+        db.del(id0);
+
+        uint64_t id1 = db.put(v1, "second");
+        CHECK(id1 == 1);
+        CHECK(db.count() == 2);
         CHECK(db.count_live() == 1);
 
-        auto hits = db.search(v0, 2);
-        bool found = false;
-        for (auto & h : hits) if (h.id == 0) found = true;
-        CHECK(!found);
+        auto hits = db.search(v1, 1);
+        CHECK(!hits.empty());
+        CHECK(hits[0].id == id1);
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("delete_update: basic update") {
-    std::string path = "/tmp/logosdb_test_update";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim});
-
-    auto v0 = unit_vec(dim, 3100);
-    auto v1 = unit_vec(dim, 3200);
-    auto v_new = unit_vec(dim, 3300);
-
-    db.put(v0, "old zero");
-    db.put(v1, "keep one");
-    CHECK(db.count_live() == 2);
-
-    uint64_t new_id = db.update(0, v_new, "new zero", "2025-07-01T00:00:00Z");
-    CHECK(new_id == 2);
-    CHECK(db.count() == 3);
-    CHECK(db.count_live() == 2);
-
-    auto hits_new = db.search(v_new, 1);
-    CHECK(!hits_new.empty());
-    CHECK(hits_new[0].id == new_id);
-    CHECK(hits_new[0].text == "new zero");
-    CHECK(hits_new[0].timestamp == "2025-07-01T00:00:00Z");
-
-    auto hits_old = db.search(v0, 3);
-    bool old_found = false;
-    for (auto & h : hits_old) if (h.id == 0) old_found = true;
-    CHECK(!old_found);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("delete_update: update errors") {
-    std::string path = "/tmp/logosdb_test_update_err";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 32});
-    auto v0 = unit_vec(32, 3400);
-    auto v1 = unit_vec(32, 3500);
-    db.put(v0, "a");
-
-    char * err = nullptr;
-    uint64_t r = logosdb_update(db.handle(), 99, v1.data(), 32, "x", nullptr, &err);
-    CHECK(r == UINT64_MAX);
-    CHECK(err != nullptr);
-    free(err); err = nullptr;
-
-    auto wrong = unit_vec(16, 3600);
-    r = logosdb_update(db.handle(), 0, wrong.data(), 16, "x", nullptr, &err);
-    CHECK(r == UINT64_MAX);
-    CHECK(err != nullptr);
-    free(err); err = nullptr;
-
-    logosdb_delete(db.handle(), 0, &err);
-    free(err); err = nullptr;
-    r = logosdb_update(db.handle(), 0, v1.data(), 32, "x", nullptr, &err);
-    CHECK(r == UINT64_MAX);
-    CHECK(err != nullptr);
-    free(err);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("delete_update: delete and reput independence") {
-    std::string path = "/tmp/logosdb_test_delete_reput";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-    logosdb::DB db(path, {.dim = dim});
-
-    auto v0 = unit_vec(dim, 3700);
-    auto v1 = unit_vec(dim, 3800);
-
-    uint64_t id0 = db.put(v0, "first");
-    db.del(id0);
-
-    uint64_t id1 = db.put(v1, "second");
-    CHECK(id1 == 1);
-    CHECK(db.count() == 2);
-    CHECK(db.count_live() == 1);
-
-    auto hits = db.search(v1, 1);
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == id1);
-
-    std::filesystem::remove_all(path);
-}
-
-} // TEST_SUITE("delete_update")
+}  // TEST_SUITE("delete_update")
 
 // ============================================================================
 // Test Suite: WAL and Crash Recovery
 // ============================================================================
 
-TEST_SUITE("wal") {
-
-TEST_CASE("wal: crash recovery replay") {
-    std::string path = "/tmp/logosdb_test_wal";
-    std::filesystem::remove_all(path);
-
+TEST_SUITE("wal")
+{
+    TEST_CASE("wal: crash recovery replay")
     {
-        logosdb::DB db(path, {.dim = 32});
-        auto v0 = unit_vec(32, 7000);
-        auto v1 = unit_vec(32, 7100);
-        db.put(v0, "first", "2025-01-01T00:00:00Z");
-        db.put(v1, "second", "2025-02-01T00:00:00Z");
-        CHECK(db.count() == 2);
+        std::string path = "/tmp/logosdb_test_wal";
+        std::filesystem::remove_all(path);
+
+        {
+            logosdb::DB db(path, {.dim = 32});
+            auto v0 = unit_vec(32, 7000);
+            auto v1 = unit_vec(32, 7100);
+            db.put(v0, "first", "2025-01-01T00:00:00Z");
+            db.put(v1, "second", "2025-02-01T00:00:00Z");
+            CHECK(db.count() == 2);
+        }
+
+        {
+            int fd = ::open((path + "/wal.log").c_str(), O_RDWR);
+            CHECK(fd >= 0);
+
+            ::lseek(fd, 0, SEEK_END);
+
+            uint8_t state = 0;
+            ::write(fd, &state, 1);
+
+            uint32_t dim = 32;
+            ::write(fd, &dim, 4);
+
+            auto v2 = unit_vec(32, 7200);
+            uint32_t vec_bytes = 32 * sizeof(float);
+            ::write(fd, &vec_bytes, 4);
+            ::write(fd, v2.data(), vec_bytes);
+
+            std::string text = "third (from wal)";
+            uint32_t text_len = text.size();
+            ::write(fd, &text_len, 4);
+            ::write(fd, text.data(), text_len);
+
+            std::string ts = "2025-03-01T00:00:00Z";
+            uint32_t ts_len = ts.size();
+            ::write(fd, &ts_len, 4);
+            ::write(fd, ts.data(), ts_len);
+
+            uint64_t expected_id = 2;
+            ::write(fd, &expected_id, 8);
+
+            ::fsync(fd);
+            ::close(fd);
+        }
+
+        {
+            logosdb::DB db(path, {.dim = 32});
+            CHECK(db.count() == 3);
+
+            auto v2 = unit_vec(32, 7200);
+            auto hits = db.search(v2, 1);
+            CHECK(!hits.empty());
+            CHECK(hits[0].text == "third (from wal)");
+            CHECK(hits[0].id == 2);
+        }
+
+        {
+            logosdb::DB db(path, {.dim = 32});
+            CHECK(db.count() == 3);
+
+            auto v2 = unit_vec(32, 7200);
+            auto hits = db.search(v2, 1);
+            CHECK(!hits.empty());
+            CHECK(hits[0].text == "third (from wal)");
+        }
+
+        std::filesystem::remove_all(path);
     }
 
-    {
-        int fd = ::open((path + "/wal.log").c_str(), O_RDWR);
-        CHECK(fd >= 0);
-
-        ::lseek(fd, 0, SEEK_END);
-
-        uint8_t state = 0;
-        ::write(fd, &state, 1);
-
-        uint32_t dim = 32;
-        ::write(fd, &dim, 4);
-
-        auto v2 = unit_vec(32, 7200);
-        uint32_t vec_bytes = 32 * sizeof(float);
-        ::write(fd, &vec_bytes, 4);
-        ::write(fd, v2.data(), vec_bytes);
-
-        std::string text = "third (from wal)";
-        uint32_t text_len = text.size();
-        ::write(fd, &text_len, 4);
-        ::write(fd, text.data(), text_len);
-
-        std::string ts = "2025-03-01T00:00:00Z";
-        uint32_t ts_len = ts.size();
-        ::write(fd, &ts_len, 4);
-        ::write(fd, ts.data(), ts_len);
-
-        uint64_t expected_id = 2;
-        ::write(fd, &expected_id, 8);
-
-        ::fsync(fd);
-        ::close(fd);
-    }
-
-    {
-        logosdb::DB db(path, {.dim = 32});
-        CHECK(db.count() == 3);
-
-        auto v2 = unit_vec(32, 7200);
-        auto hits = db.search(v2, 1);
-        CHECK(!hits.empty());
-        CHECK(hits[0].text == "third (from wal)");
-        CHECK(hits[0].id == 2);
-    }
-
-    {
-        logosdb::DB db(path, {.dim = 32});
-        CHECK(db.count() == 3);
-
-        auto v2 = unit_vec(32, 7200);
-        auto hits = db.search(v2, 1);
-        CHECK(!hits.empty());
-        CHECK(hits[0].text == "third (from wal)");
-    }
-
-    std::filesystem::remove_all(path);
-}
-
-} // TEST_SUITE("wal")
+}  // TEST_SUITE("wal")
 
 // ============================================================================
 // Test Suite: Batch Operations
 // ============================================================================
 
-TEST_SUITE("batch") {
-
-TEST_CASE("batch: basic put_batch") {
-    std::string path = "/tmp/logosdb_test_batch";
-    std::filesystem::remove_all(path);
-
+TEST_SUITE("batch")
+{
+    TEST_CASE("batch: basic put_batch")
     {
-        logosdb::DB db(path, {.dim = 32});
+        std::string path = "/tmp/logosdb_test_batch";
+        std::filesystem::remove_all(path);
 
-        int n = 100;
-        std::vector<float> embeddings;
-        embeddings.reserve(n * 32);
-        std::vector<std::string> texts;
-        std::vector<std::string> timestamps;
+        {
+            logosdb::DB db(path, {.dim = 32});
 
-        for (int i = 0; i < n; ++i) {
-            auto v = unit_vec(32, 8000 + i);
-            embeddings.insert(embeddings.end(), v.begin(), v.end());
-            texts.push_back("text_" + std::to_string(i));
-            timestamps.push_back("2025-01-01T00:00:" + std::to_string(i) + "Z");
+            int n = 100;
+            std::vector<float> embeddings;
+            embeddings.reserve(n * 32);
+            std::vector<std::string> texts;
+            std::vector<std::string> timestamps;
+
+            for (int i = 0; i < n; ++i)
+            {
+                auto v = unit_vec(32, 8000 + i);
+                embeddings.insert(embeddings.end(), v.begin(), v.end());
+                texts.push_back("text_" + std::to_string(i));
+                timestamps.push_back("2025-01-01T00:00:" + std::to_string(i) + "Z");
+            }
+
+            auto ids = db.put_batch(embeddings, n, texts, timestamps);
+            CHECK((int)ids.size() == n);
+            CHECK(db.count() == (size_t)n);
+
+            for (int i = 0; i < n; ++i)
+            {
+                CHECK(ids[i] == (uint64_t)i);
+            }
+
+            for (int i = 0; i < n; ++i)
+            {
+                auto v = unit_vec(32, 8000 + i);
+                auto hits = db.search(v, 1);
+                CHECK(!hits.empty());
+                CHECK(hits[0].id == (uint64_t)i);
+                CHECK(hits[0].text == "text_" + std::to_string(i));
+            }
         }
 
-        auto ids = db.put_batch(embeddings, n, texts, timestamps);
-        CHECK((int)ids.size() == n);
-        CHECK(db.count() == (size_t)n);
+        {
+            logosdb::DB db(path, {.dim = 32});
+            CHECK(db.count() == 100);
 
-        for (int i = 0; i < n; ++i) {
-            CHECK(ids[i] == (uint64_t)i);
-        }
-
-        for (int i = 0; i < n; ++i) {
-            auto v = unit_vec(32, 8000 + i);
-            auto hits = db.search(v, 1);
+            auto v50 = unit_vec(32, 8050);
+            auto hits = db.search(v50, 1);
             CHECK(!hits.empty());
-            CHECK(hits[0].id == (uint64_t)i);
-            CHECK(hits[0].text == "text_" + std::to_string(i));
+            CHECK(hits[0].id == 50);
+            CHECK(hits[0].text == "text_50");
         }
+
+        std::filesystem::remove_all(path);
     }
 
+    TEST_CASE("batch: empty and edge cases")
     {
-        logosdb::DB db(path, {.dim = 32});
-        CHECK(db.count() == 100);
+        std::string path = "/tmp/logosdb_test_batch_empty";
+        std::filesystem::remove_all(path);
 
-        auto v50 = unit_vec(32, 8050);
-        auto hits = db.search(v50, 1);
-        CHECK(!hits.empty());
-        CHECK(hits[0].id == 50);
-        CHECK(hits[0].text == "text_50");
-    }
+        {
+            logosdb::DB db(path, {.dim = 32});
 
-    std::filesystem::remove_all(path);
-}
+            std::vector<float> embeddings;
+            auto ids = db.put_batch(embeddings, 0);
+            CHECK(ids.empty());
+            CHECK(db.count() == 0);
 
-TEST_CASE("batch: empty and edge cases") {
-    std::string path = "/tmp/logosdb_test_batch_empty";
-    std::filesystem::remove_all(path);
+            auto v = unit_vec(32, 9000);
+            embeddings = v;
+            ids = db.put_batch(embeddings, 1);
+            CHECK(ids.size() == 1);
+            CHECK(db.count() == 1);
 
-    {
-        logosdb::DB db(path, {.dim = 32});
+            embeddings.clear();
+            for (int i = 0; i < 10; ++i)
+            {
+                auto v2 = unit_vec(32, 9100 + i);
+                embeddings.insert(embeddings.end(), v2.begin(), v2.end());
+            }
+            ids = db.put_batch(embeddings, 10);
+            CHECK(ids.size() == 10);
+            CHECK(db.count() == 11);
 
-        std::vector<float> embeddings;
-        auto ids = db.put_batch(embeddings, 0);
-        CHECK(ids.empty());
-        CHECK(db.count() == 0);
-
-        auto v = unit_vec(32, 9000);
-        embeddings = v;
-        ids = db.put_batch(embeddings, 1);
-        CHECK(ids.size() == 1);
-        CHECK(db.count() == 1);
-
-        embeddings.clear();
-        for (int i = 0; i < 10; ++i) {
-            auto v2 = unit_vec(32, 9100 + i);
-            embeddings.insert(embeddings.end(), v2.begin(), v2.end());
+            auto v_search = unit_vec(32, 9105);
+            auto hits = db.search(v_search, 1);
+            CHECK(!hits.empty());
+            CHECK(hits[0].id == 6);
         }
-        ids = db.put_batch(embeddings, 10);
-        CHECK(ids.size() == 10);
-        CHECK(db.count() == 11);
 
-        auto v_search = unit_vec(32, 9105);
-        auto hits = db.search(v_search, 1);
-        CHECK(!hits.empty());
-        CHECK(hits[0].id == 6);
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
-
-} // TEST_SUITE("batch")
+}  // TEST_SUITE("batch")
 
 // ============================================================================
 // Test Suite: Timestamp Range Search
 // ============================================================================
 
-TEST_SUITE("ts_range") {
+TEST_SUITE("ts_range")
+{
+    TEST_CASE("ts_range: basic functionality")
+    {
+        std::string path = "/tmp/logosdb_test_ts_range";
+        std::filesystem::remove_all(path);
 
-TEST_CASE("ts_range: basic functionality") {
-    std::string path = "/tmp/logosdb_test_ts_range";
-    std::filesystem::remove_all(path);
+        int dim = 64;
+        logosdb::DB db(path, {.dim = dim});
 
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim});
+        auto v0 = unit_vec(dim, 10000);
+        auto v1 = unit_vec(dim, 10100);
+        auto v2 = unit_vec(dim, 10200);
+        auto v3 = unit_vec(dim, 10300);
 
-    auto v0 = unit_vec(dim, 10000);
-    auto v1 = unit_vec(dim, 10100);
-    auto v2 = unit_vec(dim, 10200);
-    auto v3 = unit_vec(dim, 10300);
+        db.put(v0, "early morning", "2025-01-15T08:00:00Z");
+        db.put(v1, "mid morning", "2025-01-15T10:00:00Z");
+        db.put(v2, "afternoon", "2025-01-15T14:00:00Z");
+        db.put(v3, "evening", "2025-01-15T20:00:00Z");
 
-    db.put(v0, "early morning", "2025-01-15T08:00:00Z");
-    db.put(v1, "mid morning",   "2025-01-15T10:00:00Z");
-    db.put(v2, "afternoon",     "2025-01-15T14:00:00Z");
-    db.put(v3, "evening",       "2025-01-15T20:00:00Z");
+        auto hits = db.search_ts_range(v0, 5, "2025-01-15T09:00:00Z", "2025-01-15T15:00:00Z");
+        CHECK(hits.size() == 2);
 
-    auto hits = db.search_ts_range(v0, 5, "2025-01-15T09:00:00Z", "2025-01-15T15:00:00Z");
-    CHECK(hits.size() == 2);
-
-    bool found_v1 = false, found_v2 = false;
-    for (auto & h : hits) {
-        if (h.id == 1) found_v1 = true;
-        if (h.id == 2) found_v2 = true;
-    }
-    CHECK(found_v1);
-    CHECK(found_v2);
-
-    hits = db.search_ts_range(v0, 5, "2025-01-15T14:00:00Z", "");
-    CHECK(hits.size() == 2);
-
-    hits = db.search_ts_range(v0, 4, "", "");
-    CHECK(hits.size() == 4);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("ts_range: edge cases and C API") {
-    std::string path = "/tmp/logosdb_test_ts_range_edge";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-    logosdb::DB db(path, {.dim = dim});
-
-    auto v0 = unit_vec(dim, 11000);
-    auto v1 = unit_vec(dim, 11100);
-    db.put(v0, "entry1", "2025-02-01T12:00:00Z");
-    db.put(v1, "entry2", "2025-02-01T14:00:00Z");
-
-    auto hits = db.search_ts_range(v0, 5, "2025-12-01T00:00:00Z", "2025-12-31T23:59:59Z");
-    CHECK(hits.empty());
-
-    auto v2 = unit_vec(dim, 11200);
-    db.put(v2, "no timestamp", "");
-    hits = db.search_ts_range(v0, 5, "", "");
-    CHECK(hits.size() == 3);
-
-    char * err = nullptr;
-    logosdb_search_result_t * r = logosdb_search_ts_range(
-        db.handle(), v0.data(), dim, 2,
-        "2025-02-01T00:00:00Z", "2025-02-01T23:59:59Z",
-        10, &err);
-    CHECK(r != nullptr);
-    CHECK(err == nullptr);
-    if (r) {
-        CHECK(logosdb_result_count(r) == 2);
-        logosdb_result_free(r);
-    }
-
-    r = logosdb_search_ts_range(nullptr, v0.data(), dim, 1, nullptr, nullptr, 10, &err);
-    CHECK(r == nullptr);
-    CHECK(err != nullptr);
-    free(err); err = nullptr;
-
-    r = logosdb_search_ts_range(db.handle(), v0.data(), dim, 0, nullptr, nullptr, 10, &err);
-    CHECK(r == nullptr);
-    CHECK(err != nullptr);
-    free(err);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("ts_range: recall with alternating timestamps") {
-    std::string path = "/tmp/logosdb_test_ts_range_recall";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    int n = 100;
-    logosdb::DB db(path, {.dim = dim, .max_elements = 200});
-
-    std::vector<std::vector<float>> morning_vecs;
-    std::vector<std::vector<float>> evening_vecs;
-
-    for (int i = 0; i < n; ++i) {
-        auto v = unit_vec(dim, 12000 + i);
-        if (i % 2 == 0) {
-            morning_vecs.push_back(v);
-            db.put(v, "morning_" + std::to_string(i), "2025-03-01T09:00:00Z");
-        } else {
-            evening_vecs.push_back(v);
-            db.put(v, "evening_" + std::to_string(i), "2025-03-01T18:00:00Z");
+        bool found_v1 = false, found_v2 = false;
+        for (auto& h : hits)
+        {
+            if (h.id == 1)
+                found_v1 = true;
+            if (h.id == 2)
+                found_v2 = true;
         }
+        CHECK(found_v1);
+        CHECK(found_v2);
+
+        hits = db.search_ts_range(v0, 5, "2025-01-15T14:00:00Z", "");
+        CHECK(hits.size() == 2);
+
+        hits = db.search_ts_range(v0, 4, "", "");
+        CHECK(hits.size() == 4);
+
+        std::filesystem::remove_all(path);
     }
 
-    auto query = morning_vecs[0];
-    auto hits = db.search_ts_range(query, 10, "2025-03-01T00:00:00Z", "2025-03-01T12:00:00Z");
+    TEST_CASE("ts_range: edge cases and C API")
+    {
+        std::string path = "/tmp/logosdb_test_ts_range_edge";
+        std::filesystem::remove_all(path);
 
-    bool all_morning = true;
-    for (auto & h : hits) {
-        if (h.id % 2 != 0) {
-            all_morning = false;
-            break;
+        int dim = 32;
+        logosdb::DB db(path, {.dim = dim});
+
+        auto v0 = unit_vec(dim, 11000);
+        auto v1 = unit_vec(dim, 11100);
+        db.put(v0, "entry1", "2025-02-01T12:00:00Z");
+        db.put(v1, "entry2", "2025-02-01T14:00:00Z");
+
+        auto hits = db.search_ts_range(v0, 5, "2025-12-01T00:00:00Z", "2025-12-31T23:59:59Z");
+        CHECK(hits.empty());
+
+        auto v2 = unit_vec(dim, 11200);
+        db.put(v2, "no timestamp", "");
+        hits = db.search_ts_range(v0, 5, "", "");
+        CHECK(hits.size() == 3);
+
+        char* err = nullptr;
+        logosdb_search_result_t* r = logosdb_search_ts_range(db.handle(),
+                                                             v0.data(),
+                                                             dim,
+                                                             2,
+                                                             "2025-02-01T00:00:00Z",
+                                                             "2025-02-01T23:59:59Z",
+                                                             10,
+                                                             &err);
+        CHECK(r != nullptr);
+        CHECK(err == nullptr);
+        if (r)
+        {
+            CHECK(logosdb_result_count(r) == 2);
+            logosdb_result_free(r);
         }
+
+        r = logosdb_search_ts_range(nullptr, v0.data(), dim, 1, nullptr, nullptr, 10, &err);
+        CHECK(r == nullptr);
+        CHECK(err != nullptr);
+        free(err);
+        err = nullptr;
+
+        r = logosdb_search_ts_range(db.handle(), v0.data(), dim, 0, nullptr, nullptr, 10, &err);
+        CHECK(r == nullptr);
+        CHECK(err != nullptr);
+        free(err);
+
+        std::filesystem::remove_all(path);
     }
-    CHECK(all_morning);
-    CHECK(hits.size() == 10);
 
-    for (size_t i = 1; i < hits.size(); ++i) {
-        CHECK(hits[i-1].score >= hits[i].score);
+    TEST_CASE("ts_range: recall with alternating timestamps")
+    {
+        std::string path = "/tmp/logosdb_test_ts_range_recall";
+        std::filesystem::remove_all(path);
+
+        int dim = 64;
+        int n = 100;
+        logosdb::DB db(path, {.dim = dim, .max_elements = 200});
+
+        std::vector<std::vector<float>> morning_vecs;
+        std::vector<std::vector<float>> evening_vecs;
+
+        for (int i = 0; i < n; ++i)
+        {
+            auto v = unit_vec(dim, 12000 + i);
+            if (i % 2 == 0)
+            {
+                morning_vecs.push_back(v);
+                db.put(v, "morning_" + std::to_string(i), "2025-03-01T09:00:00Z");
+            }
+            else
+            {
+                evening_vecs.push_back(v);
+                db.put(v, "evening_" + std::to_string(i), "2025-03-01T18:00:00Z");
+            }
+        }
+
+        auto query = morning_vecs[0];
+        auto hits = db.search_ts_range(query, 10, "2025-03-01T00:00:00Z", "2025-03-01T12:00:00Z");
+
+        bool all_morning = true;
+        for (auto& h : hits)
+        {
+            if (h.id % 2 != 0)
+            {
+                all_morning = false;
+                break;
+            }
+        }
+        CHECK(all_morning);
+        CHECK(hits.size() == 10);
+
+        for (size_t i = 1; i < hits.size(); ++i)
+        {
+            CHECK(hits[i - 1].score >= hits[i].score);
+        }
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
-
-} // TEST_SUITE("ts_range")
+}  // TEST_SUITE("ts_range")
 
 // ============================================================================
 // Test Suite: Distance Metrics
 // ============================================================================
 
-TEST_SUITE("distance") {
-
-TEST_CASE("distance: cosine auto-normalization") {
-    std::string path = "/tmp/logosdb_test_cosine";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_COSINE});
-
-    auto v0 = unit_vec(dim, 13000);
-    auto v1 = unit_vec(dim, 13100);
-
-    for (int i = 0; i < dim; ++i) {
-        v0[i] *= 5.0f;
-        v1[i] *= 3.0f;
-    }
-
-    db.put(v0, "scaled v0");
-    db.put(v1, "scaled v1");
-
-    auto scaled_query = v0;
-    auto hits = db.search(scaled_query, 2);
-
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == 0);
-    CHECK(hits[0].score > 0.99f);
-
-    auto self_hits = db.search(scaled_query, 1);
-    CHECK(!self_hits.empty());
-    CHECK(self_hits[0].score > 0.99f);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("distance: L2 (Euclidean)") {
-    std::string path = "/tmp/logosdb_test_l2";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_L2});
-
-    auto v0 = unit_vec(dim, 14000);
-    auto v1 = unit_vec(dim, 14100);
-
-    db.put(v0, "v0");
-    db.put(v1, "v1");
-
-    auto hits = db.search(v0, 2);
-
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == 0);
-    CHECK(hits[0].score > hits[1].score);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("distance: persistence across reopen") {
-    std::string path = "/tmp/logosdb_test_dist_persist";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-
+TEST_SUITE("distance")
+{
+    TEST_CASE("distance: cosine auto-normalization")
     {
-        logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_COSINE});
-        auto v = unit_vec(dim, 15000);
-        db.put(v, "test");
-    }
+        std::string path = "/tmp/logosdb_test_cosine";
+        std::filesystem::remove_all(path);
 
-    {
+        int dim = 64;
         logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_COSINE});
-        auto v = unit_vec(dim, 15000);
-        auto hits = db.search(v, 1);
+
+        auto v0 = unit_vec(dim, 13000);
+        auto v1 = unit_vec(dim, 13100);
+
+        for (int i = 0; i < dim; ++i)
+        {
+            v0[i] *= 5.0f;
+            v1[i] *= 3.0f;
+        }
+
+        db.put(v0, "scaled v0");
+        db.put(v1, "scaled v1");
+
+        auto scaled_query = v0;
+        auto hits = db.search(scaled_query, 2);
+
         CHECK(!hits.empty());
         CHECK(hits[0].id == 0);
+        CHECK(hits[0].score > 0.99f);
+
+        auto self_hits = db.search(scaled_query, 1);
+        CHECK(!self_hits.empty());
+        CHECK(self_hits[0].score > 0.99f);
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("distance: mismatch error") {
-    std::string path = "/tmp/logosdb_test_dist_mismatch";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-
+    TEST_CASE("distance: L2 (Euclidean)")
     {
-        logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_COSINE});
-        auto v = unit_vec(dim, 16000);
-        db.put(v, "test");
-    }
+        std::string path = "/tmp/logosdb_test_l2";
+        std::filesystem::remove_all(path);
 
-    bool caught = false;
-    try {
+        int dim = 64;
         logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_L2});
-    } catch (const std::runtime_error & e) {
-        caught = true;
-        CHECK(std::string(e.what()).find("distance metric mismatch") != std::string::npos);
+
+        auto v0 = unit_vec(dim, 14000);
+        auto v1 = unit_vec(dim, 14100);
+
+        db.put(v0, "v0");
+        db.put(v1, "v1");
+
+        auto hits = db.search(v0, 2);
+
+        CHECK(!hits.empty());
+        CHECK(hits[0].id == 0);
+        CHECK(hits[0].score > hits[1].score);
+
+        std::filesystem::remove_all(path);
     }
-    CHECK(caught);
 
-    logosdb_options_t * opts = logosdb_options_create();
-    CHECK(logosdb_options_set_distance(opts, LOGOSDB_DIST_IP) == 0);
-    CHECK(logosdb_options_set_distance(opts, LOGOSDB_DIST_COSINE) == 0);
-    CHECK(logosdb_options_set_distance(opts, LOGOSDB_DIST_L2) == 0);
-    CHECK(logosdb_options_set_distance(opts, 99) == -1);
-    CHECK(logosdb_options_set_distance(nullptr, LOGOSDB_DIST_IP) == -1);
-    logosdb_options_destroy(opts);
+    TEST_CASE("distance: persistence across reopen")
+    {
+        std::string path = "/tmp/logosdb_test_dist_persist";
+        std::filesystem::remove_all(path);
 
-    std::filesystem::remove_all(path);
-}
+        int dim = 32;
 
-} // TEST_SUITE("distance")
+        {
+            logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_COSINE});
+            auto v = unit_vec(dim, 15000);
+            db.put(v, "test");
+        }
+
+        {
+            logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_COSINE});
+            auto v = unit_vec(dim, 15000);
+            auto hits = db.search(v, 1);
+            CHECK(!hits.empty());
+            CHECK(hits[0].id == 0);
+        }
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("distance: mismatch error")
+    {
+        std::string path = "/tmp/logosdb_test_dist_mismatch";
+        std::filesystem::remove_all(path);
+
+        int dim = 32;
+
+        {
+            logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_COSINE});
+            auto v = unit_vec(dim, 16000);
+            db.put(v, "test");
+        }
+
+        bool caught = false;
+        try
+        {
+            logosdb::DB db(path, {.dim = dim, .distance = LOGOSDB_DIST_L2});
+        }
+        catch (const std::runtime_error& e)
+        {
+            caught = true;
+            CHECK(std::string(e.what()).find("distance metric mismatch") != std::string::npos);
+        }
+        CHECK(caught);
+
+        logosdb_options_t* opts = logosdb_options_create();
+        CHECK(logosdb_options_set_distance(opts, LOGOSDB_DIST_IP) == 0);
+        CHECK(logosdb_options_set_distance(opts, LOGOSDB_DIST_COSINE) == 0);
+        CHECK(logosdb_options_set_distance(opts, LOGOSDB_DIST_L2) == 0);
+        CHECK(logosdb_options_set_distance(opts, 99) == -1);
+        CHECK(logosdb_options_set_distance(nullptr, LOGOSDB_DIST_IP) == -1);
+        logosdb_options_destroy(opts);
+
+        std::filesystem::remove_all(path);
+    }
+
+}  // TEST_SUITE("distance")
 
 // ============================================================================
 // Test Suite: CLI
 // ============================================================================
 
-TEST_SUITE("cli") {
-
-TEST_CASE("cli: info reads dim from header") {
-    std::string path = "/tmp/logosdb_test_cli_info";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 64});
-    auto v = unit_vec(64, 17000);
-    db.put(v, "test entry", "2025-01-01T00:00:00Z");
-
-    std::string output;
-    int rc = run_cli("info " + path, output);
-    CHECK(rc == 0);
-    CHECK(output.find("dim        : 64") != std::string::npos);
-    CHECK(output.find("count      : 1") != std::string::npos);
-
-    output.clear();
-    rc = run_cli("info " + path + " --json", output);
-    CHECK(rc == 0);
-    CHECK(output.find("\"dim\": 64") != std::string::npos);
-    CHECK(output.find("\"count\": 1") != std::string::npos);
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("cli: export/import roundtrip") {
-    std::string path = "/tmp/logosdb_test_cli_export";
-    std::string import_path = "/tmp/logosdb_test_cli_import";
-    std::string export_file = "/tmp/test_export.jsonl";
-    std::filesystem::remove_all(path);
-    std::filesystem::remove_all(import_path);
-    std::remove(export_file.c_str());
-
-    logosdb::DB db(path, {.dim = 32});
-    auto v0 = unit_vec(32, 18000);
-    auto v1 = unit_vec(32, 18100);
-    db.put(v0, "first", "2025-01-10T00:00:00Z");
-    db.put(v1, "second", "2025-01-11T00:00:00Z");
-
-    std::string output;
-    int rc = run_cli("export " + path + " --output " + export_file, output);
-    CHECK(rc == 0);
-    CHECK(output.find("Exported 2 rows") != std::string::npos);
-
-    std::ifstream check(export_file);
-    CHECK(check.good());
-    check.close();
-
-    rc = run_cli("import " + import_path + " --dim 32 --input " + export_file, output);
-    CHECK(rc == 0);
-    CHECK(output.find("Imported 2 rows") != std::string::npos);
-
-    logosdb::DB import_db(import_path, {.dim = 32});
-    CHECK(import_db.count() == 2);
-
-    std::filesystem::remove_all(path);
-    std::filesystem::remove_all(import_path);
-    std::remove(export_file.c_str());
-}
-
-TEST_CASE("cli: search with timestamp range") {
-    std::string path = "/tmp/logosdb_test_cli_ts";
-    std::filesystem::remove_all(path);
-
-    logosdb::DB db(path, {.dim = 32});
-    auto v0 = unit_vec(32, 19000);
-    auto v1 = unit_vec(32, 19100);
-    db.put(v0, "early", "2025-01-10T08:00:00Z");
-    db.put(v1, "late", "2025-01-15T18:00:00Z");
-
+TEST_SUITE("cli")
+{
+    TEST_CASE("cli: info reads dim from header")
     {
-        std::ofstream qf("/tmp/query_vec.bin", std::ios::binary);
-        qf.write(reinterpret_cast<const char*>(v0.data()), 32 * sizeof(float));
-        qf.close();
+        std::string path = "/tmp/logosdb_test_cli_info";
+        std::filesystem::remove_all(path);
+
+        logosdb::DB db(path, {.dim = 64});
+        auto v = unit_vec(64, 17000);
+        db.put(v, "test entry", "2025-01-01T00:00:00Z");
+
+        std::string output;
+        int rc = run_cli("info " + path, output);
+        CHECK(rc == 0);
+        CHECK(output.find("dim        : 64") != std::string::npos);
+        CHECK(output.find("count      : 1") != std::string::npos);
+
+        output.clear();
+        rc = run_cli("info " + path + " --json", output);
+        CHECK(rc == 0);
+        CHECK(output.find("\"dim\": 64") != std::string::npos);
+        CHECK(output.find("\"count\": 1") != std::string::npos);
+
+        std::filesystem::remove_all(path);
     }
 
-    std::string output;
-    int rc = run_cli("search " + path + " --query-file /tmp/query_vec.bin --top-k 10 --json", output);
-    CHECK(rc == 0);
-    int results = 0;
-    size_t pos = 0;
-    while ((pos = output.find("\"rank\":", pos)) != std::string::npos) {
-        results++;
-        pos++;
+    TEST_CASE("cli: export/import roundtrip")
+    {
+        std::string path = "/tmp/logosdb_test_cli_export";
+        std::string import_path = "/tmp/logosdb_test_cli_import";
+        std::string export_file = "/tmp/test_export.jsonl";
+        std::filesystem::remove_all(path);
+        std::filesystem::remove_all(import_path);
+        std::remove(export_file.c_str());
+
+        logosdb::DB db(path, {.dim = 32});
+        auto v0 = unit_vec(32, 18000);
+        auto v1 = unit_vec(32, 18100);
+        db.put(v0, "first", "2025-01-10T00:00:00Z");
+        db.put(v1, "second", "2025-01-11T00:00:00Z");
+
+        std::string output;
+        int rc = run_cli("export " + path + " --output " + export_file, output);
+        CHECK(rc == 0);
+        CHECK(output.find("Exported 2 rows") != std::string::npos);
+
+        std::ifstream check(export_file);
+        CHECK(check.good());
+        check.close();
+
+        rc = run_cli("import " + import_path + " --dim 32 --input " + export_file, output);
+        CHECK(rc == 0);
+        CHECK(output.find("Imported 2 rows") != std::string::npos);
+
+        logosdb::DB import_db(import_path, {.dim = 32});
+        CHECK(import_db.count() == 2);
+
+        std::filesystem::remove_all(path);
+        std::filesystem::remove_all(import_path);
+        std::remove(export_file.c_str());
     }
-    CHECK(results == 2);
 
-    output.clear();
-    rc = run_cli("search " + path + " --query-file /tmp/query_vec.bin --ts-from 2025-01-01T00:00:00Z --ts-to 2025-01-12T00:00:00Z --top-k 10 --json", output);
-    CHECK(rc == 0);
-    CHECK(output.find("early") != std::string::npos);
-    CHECK(output.find("late") == std::string::npos);
+    TEST_CASE("cli: search with timestamp range")
+    {
+        std::string path = "/tmp/logosdb_test_cli_ts";
+        std::filesystem::remove_all(path);
 
-    std::filesystem::remove_all(path);
-    std::remove("/tmp/query_vec.bin");
-}
+        logosdb::DB db(path, {.dim = 32});
+        auto v0 = unit_vec(32, 19000);
+        auto v1 = unit_vec(32, 19100);
+        db.put(v0, "early", "2025-01-10T08:00:00Z");
+        db.put(v1, "late", "2025-01-15T18:00:00Z");
 
-} // TEST_SUITE("cli")
+        {
+            std::ofstream qf("/tmp/query_vec.bin", std::ios::binary);
+            qf.write(reinterpret_cast<const char*>(v0.data()), 32 * sizeof(float));
+            qf.close();
+        }
+
+        std::string output;
+        int rc = run_cli("search " + path + " --query-file /tmp/query_vec.bin --top-k 10 --json",
+                         output);
+        CHECK(rc == 0);
+        int results = 0;
+        size_t pos = 0;
+        while ((pos = output.find("\"rank\":", pos)) != std::string::npos)
+        {
+            results++;
+            pos++;
+        }
+        CHECK(results == 2);
+
+        output.clear();
+        rc = run_cli("search " + path +
+                         " --query-file /tmp/query_vec.bin --ts-from 2025-01-01T00:00:00Z --ts-to "
+                         "2025-01-12T00:00:00Z --top-k 10 --json",
+                     output);
+        CHECK(rc == 0);
+        CHECK(output.find("early") != std::string::npos);
+        CHECK(output.find("late") == std::string::npos);
+
+        std::filesystem::remove_all(path);
+        std::remove("/tmp/query_vec.bin");
+    }
+
+}  // TEST_SUITE("cli")
 
 // ============================================================================
 // Test Suite: Storage (reduced precision)
 // ============================================================================
 
-TEST_SUITE("storage") {
-
-TEST_CASE("storage: float16 basic") {
-    std::string path = "/tmp/logosdb_test_float16";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim, .dtype = LOGOSDB_DTYPE_FLOAT16});
-
-    auto v0 = unit_vec(dim, 8000);
-    auto v1 = unit_vec(dim, 8100);
-    auto v2 = unit_vec(dim, 8200);
-
-    db.put(v0, "first", "2025-01-01T00:00:00Z");
-    db.put(v1, "second", "2025-01-02T00:00:00Z");
-    db.put(v2, "third", "2025-01-03T00:00:00Z");
-
-    CHECK(db.count() == 3);
-
-    auto hits = db.search(v0, 3);
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == 0);
-    CHECK(hits[0].score > 0.99f);
-
+TEST_SUITE("storage")
+{
+    TEST_CASE("storage: float16 basic")
     {
-        logosdb::DB db2(path, {.dim = dim});
-        CHECK(db2.count() == 3);
+        std::string path = "/tmp/logosdb_test_float16";
+        std::filesystem::remove_all(path);
 
-        auto hits2 = db2.search(v1, 3);
-        CHECK(!hits2.empty());
-        CHECK(hits2[0].id == 1);
-    }
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("storage: int8 basic") {
-    std::string path = "/tmp/logosdb_test_int8";
-    std::filesystem::remove_all(path);
-
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim, .dtype = LOGOSDB_DTYPE_INT8});
-
-    auto v0 = unit_vec(dim, 9000);
-    auto v1 = unit_vec(dim, 9100);
-    auto v2 = unit_vec(dim, 9200);
-
-    db.put(v0, "first", "2025-01-01T00:00:00Z");
-    db.put(v1, "second", "2025-01-02T00:00:00Z");
-    db.put(v2, "third", "2025-01-03T00:00:00Z");
-
-    CHECK(db.count() == 3);
-
-    auto hits = db.search(v0, 3);
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == 0);
-    CHECK(hits[0].score > 0.90f);
-
-    {
-        logosdb::DB db2(path, {.dim = dim});
-        CHECK(db2.count() == 3);
-
-        auto hits2 = db2.search(v1, 3);
-        CHECK(!hits2.empty());
-        CHECK(hits2[0].id == 1);
-    }
-
-    std::filesystem::remove_all(path);
-}
-
-TEST_CASE("storage: dtype persistence") {
-    std::string path = "/tmp/logosdb_test_dtype_persist";
-    std::filesystem::remove_all(path);
-
-    int dim = 32;
-
-    {
+        int dim = 64;
         logosdb::DB db(path, {.dim = dim, .dtype = LOGOSDB_DTYPE_FLOAT16});
-        auto v = unit_vec(dim, 10000);
-        db.put(v, "test");
-    }
 
-    {
-        logosdb::DB db(path, {.dim = dim});
-        CHECK(db.count() == 1);
+        auto v0 = unit_vec(dim, 8000);
+        auto v1 = unit_vec(dim, 8100);
+        auto v2 = unit_vec(dim, 8200);
 
-        auto v = unit_vec(dim, 10000);
-        auto hits = db.search(v, 1);
+        db.put(v0, "first", "2025-01-01T00:00:00Z");
+        db.put(v1, "second", "2025-01-02T00:00:00Z");
+        db.put(v2, "third", "2025-01-03T00:00:00Z");
+
+        CHECK(db.count() == 3);
+
+        auto hits = db.search(v0, 3);
         CHECK(!hits.empty());
+        CHECK(hits[0].id == 0);
+        CHECK(hits[0].score > 0.99f);
+
+        {
+            logosdb::DB db2(path, {.dim = dim});
+            CHECK(db2.count() == 3);
+
+            auto hits2 = db2.search(v1, 3);
+            CHECK(!hits2.empty());
+            CHECK(hits2[0].id == 1);
+        }
+
+        std::filesystem::remove_all(path);
     }
 
-    std::filesystem::remove_all(path);
-}
+    TEST_CASE("storage: int8 basic")
+    {
+        std::string path = "/tmp/logosdb_test_int8";
+        std::filesystem::remove_all(path);
 
-TEST_CASE("storage: pointers stable across appends") {
-    std::string path = "/tmp/logosdb_test_stable_pointers";
-    std::filesystem::remove_all(path);
+        int dim = 64;
+        logosdb::DB db(path, {.dim = dim, .dtype = LOGOSDB_DTYPE_INT8});
 
-    int dim = 32;
-    logosdb::DB db(path, {.dim = dim});
+        auto v0 = unit_vec(dim, 9000);
+        auto v1 = unit_vec(dim, 9100);
+        auto v2 = unit_vec(dim, 9200);
 
-    auto v0 = unit_vec(dim, 20000);
-    db.put(v0, "first", "2025-01-01T00:00:00Z");
+        db.put(v0, "first", "2025-01-01T00:00:00Z");
+        db.put(v1, "second", "2025-01-02T00:00:00Z");
+        db.put(v2, "third", "2025-01-03T00:00:00Z");
 
-    size_t n_rows = 0;
-    int d = 0;
-    auto raw = db.raw_vectors(n_rows, d);
-    CHECK(!raw.empty());
-    CHECK(n_rows == 1);
+        CHECK(db.count() == 3);
 
-    float diff = 0.0f;
-    for (int i = 0; i < dim; ++i) diff += std::fabs(raw[i] - v0[i]);
-    CHECK(diff < 1e-5f);
+        auto hits = db.search(v0, 3);
+        CHECK(!hits.empty());
+        CHECK(hits[0].id == 0);
+        CHECK(hits[0].score > 0.90f);
 
-    for (int i = 0; i < 100; ++i) {
-        auto v = unit_vec(dim, 20001 + i);
-        db.put(v, "batch", "2025-01-01T00:00:00Z");
+        {
+            logosdb::DB db2(path, {.dim = dim});
+            CHECK(db2.count() == 3);
+
+            auto hits2 = db2.search(v1, 3);
+            CHECK(!hits2.empty());
+            CHECK(hits2[0].id == 1);
+        }
+
+        std::filesystem::remove_all(path);
     }
 
-    raw = db.raw_vectors(n_rows, d);
-    CHECK(n_rows == 101);
+    TEST_CASE("storage: dtype persistence")
+    {
+        std::string path = "/tmp/logosdb_test_dtype_persist";
+        std::filesystem::remove_all(path);
 
-    diff = 0.0f;
-    for (int i = 0; i < dim; ++i) diff += std::fabs(raw[i] - v0[i]);
-    CHECK(diff < 1e-5f);
+        int dim = 32;
 
-    auto hits = db.search(v0, 1);
-    CHECK(!hits.empty());
-    CHECK(hits[0].id == 0);
+        {
+            logosdb::DB db(path, {.dim = dim, .dtype = LOGOSDB_DTYPE_FLOAT16});
+            auto v = unit_vec(dim, 10000);
+            db.put(v, "test");
+        }
 
-    std::filesystem::remove_all(path);
-}
+        {
+            logosdb::DB db(path, {.dim = dim});
+            CHECK(db.count() == 1);
 
-} // TEST_SUITE("storage")
+            auto v = unit_vec(dim, 10000);
+            auto hits = db.search(v, 1);
+            CHECK(!hits.empty());
+        }
+
+        std::filesystem::remove_all(path);
+    }
+
+    TEST_CASE("storage: pointers stable across appends")
+    {
+        std::string path = "/tmp/logosdb_test_stable_pointers";
+        std::filesystem::remove_all(path);
+
+        int dim = 32;
+        logosdb::DB db(path, {.dim = dim});
+
+        auto v0 = unit_vec(dim, 20000);
+        db.put(v0, "first", "2025-01-01T00:00:00Z");
+
+        size_t n_rows = 0;
+        int d = 0;
+        auto raw = db.raw_vectors(n_rows, d);
+        CHECK(!raw.empty());
+        CHECK(n_rows == 1);
+
+        float diff = 0.0f;
+        for (int i = 0; i < dim; ++i)
+            diff += std::fabs(raw[i] - v0[i]);
+        CHECK(diff < 1e-5f);
+
+        for (int i = 0; i < 100; ++i)
+        {
+            auto v = unit_vec(dim, 20001 + i);
+            db.put(v, "batch", "2025-01-01T00:00:00Z");
+        }
+
+        raw = db.raw_vectors(n_rows, d);
+        CHECK(n_rows == 101);
+
+        diff = 0.0f;
+        for (int i = 0; i < dim; ++i)
+            diff += std::fabs(raw[i] - v0[i]);
+        CHECK(diff < 1e-5f);
+
+        auto hits = db.search(v0, 1);
+        CHECK(!hits.empty());
+        CHECK(hits[0].id == 0);
+
+        std::filesystem::remove_all(path);
+    }
+
+}  // TEST_SUITE("storage")
 
 // ============================================================================
 // Test Suite: L2 Normalization
 // ============================================================================
 
-TEST_SUITE("l2_normalize") {
+TEST_SUITE("l2_normalize")
+{
+    TEST_CASE("l2_normalize: basic random vectors")
+    {
+        std::mt19937 rng(12345);
+        std::normal_distribution<float> dist(0.0f, 1.0f);
 
-TEST_CASE("l2_normalize: basic random vectors") {
-    std::mt19937 rng(12345);
-    std::normal_distribution<float> dist(0.0f, 1.0f);
+        int dim = 128;
+        std::vector<float> vec(dim);
+        for (int i = 0; i < dim; ++i)
+            vec[i] = dist(rng);
 
-    int dim = 128;
-    std::vector<float> vec(dim);
-    for (int i = 0; i < dim; ++i) vec[i] = dist(rng);
+        float orig_norm_sq = 0.0f;
+        for (float v : vec)
+            orig_norm_sq += v * v;
+        float orig_norm = std::sqrt(orig_norm_sq);
+        CHECK(orig_norm > 5.0f);
 
-    float orig_norm_sq = 0.0f;
-    for (float v : vec) orig_norm_sq += v * v;
-    float orig_norm = std::sqrt(orig_norm_sq);
-    CHECK(orig_norm > 5.0f);
+        int rc = logosdb_l2_normalize(vec.data(), dim);
+        CHECK(rc == 0);
 
-    int rc = logosdb_l2_normalize(vec.data(), dim);
-    CHECK(rc == 0);
+        float norm_sq = 0.0f;
+        for (float v : vec)
+            norm_sq += v * v;
+        float norm = std::sqrt(norm_sq);
+        CHECK(std::abs(norm - 1.0f) < 1e-5f);
 
-    float norm_sq = 0.0f;
-    for (float v : vec) norm_sq += v * v;
-    float norm = std::sqrt(norm_sq);
-    CHECK(std::abs(norm - 1.0f) < 1e-5f);
+        std::vector<float> v2(dim);
+        for (int i = 0; i < dim; ++i)
+            v2[i] = 3.0f * dist(rng);
 
-    std::vector<float> v2(dim);
-    for (int i = 0; i < dim; ++i) v2[i] = 3.0f * dist(rng);
+        rc = logosdb_l2_normalize(v2.data(), dim);
+        CHECK(rc == 0);
 
-    rc = logosdb_l2_normalize(v2.data(), dim);
-    CHECK(rc == 0);
+        norm_sq = 0.0f;
+        for (float v : v2)
+            norm_sq += v * v;
+        norm = std::sqrt(norm_sq);
+        CHECK(std::abs(norm - 1.0f) < 1e-5f);
+    }
 
-    norm_sq = 0.0f;
-    for (float v : v2) norm_sq += v * v;
-    norm = std::sqrt(norm_sq);
-    CHECK(std::abs(norm - 1.0f) < 1e-5f);
-}
+    TEST_CASE("l2_normalize: already normalized stays unit")
+    {
+        int dim = 64;
+        auto v = unit_vec(dim, 50000);
 
-TEST_CASE("l2_normalize: already normalized stays unit") {
-    int dim = 64;
-    auto v = unit_vec(dim, 50000);
+        float norm_sq = 0.0f;
+        for (float val : v)
+            norm_sq += val * val;
+        CHECK(std::abs(std::sqrt(norm_sq) - 1.0f) < 1e-5f);
 
-    float norm_sq = 0.0f;
-    for (float val : v) norm_sq += val * val;
-    CHECK(std::abs(std::sqrt(norm_sq) - 1.0f) < 1e-5f);
+        int rc = logosdb_l2_normalize(v.data(), dim);
+        CHECK(rc == 0);
 
-    int rc = logosdb_l2_normalize(v.data(), dim);
-    CHECK(rc == 0);
+        norm_sq = 0.0f;
+        for (float val : v)
+            norm_sq += val * val;
+        float norm = std::sqrt(norm_sq);
+        CHECK(std::abs(norm - 1.0f) < 1e-5f);
+    }
 
-    norm_sq = 0.0f;
-    for (float val : v) norm_sq += val * val;
-    float norm = std::sqrt(norm_sq);
-    CHECK(std::abs(norm - 1.0f) < 1e-5f);
-}
+    TEST_CASE("l2_normalize: zero vector returns error")
+    {
+        int dim = 32;
+        std::vector<float> zero_vec(dim, 0.0f);
 
-TEST_CASE("l2_normalize: zero vector returns error") {
-    int dim = 32;
-    std::vector<float> zero_vec(dim, 0.0f);
+        int rc = logosdb_l2_normalize(zero_vec.data(), dim);
+        CHECK(rc == -1);
 
-    int rc = logosdb_l2_normalize(zero_vec.data(), dim);
-    CHECK(rc == -1);
+        for (float v : zero_vec)
+            CHECK(v == 0.0f);
+    }
 
-    for (float v : zero_vec) CHECK(v == 0.0f);
-}
+    TEST_CASE("l2_normalize: very small values")
+    {
+        int dim = 128;
+        std::vector<float> small_vec(dim);
+        for (int i = 0; i < dim; ++i)
+            small_vec[i] = 1e-20f;
 
-TEST_CASE("l2_normalize: very small values") {
-    int dim = 128;
-    std::vector<float> small_vec(dim);
-    for (int i = 0; i < dim; ++i) small_vec[i] = 1e-20f;
+        int rc = logosdb_l2_normalize(small_vec.data(), dim);
+        CHECK(rc == 0);
 
-    int rc = logosdb_l2_normalize(small_vec.data(), dim);
-    CHECK(rc == 0);
+        float norm_sq = 0.0f;
+        for (float v : small_vec)
+            norm_sq += v * v;
+        float norm = std::sqrt(norm_sq);
+        CHECK(std::abs(norm - 1.0f) < 1e-5f);
+    }
 
-    float norm_sq = 0.0f;
-    for (float v : small_vec) norm_sq += v * v;
-    float norm = std::sqrt(norm_sq);
-    CHECK(std::abs(norm - 1.0f) < 1e-5f);
-}
+    TEST_CASE("l2_normalize: C++ wrappers")
+    {
+        int dim = 64;
+        std::mt19937 rng(60000);
+        std::normal_distribution<float> dist(0.0f, 1.0f);
 
-TEST_CASE("l2_normalize: C++ wrappers") {
-    int dim = 64;
-    std::mt19937 rng(60000);
-    std::normal_distribution<float> dist(0.0f, 1.0f);
+        std::vector<float> v1(dim);
+        for (int i = 0; i < dim; ++i)
+            v1[i] = 5.0f * dist(rng);
 
-    std::vector<float> v1(dim);
-    for (int i = 0; i < dim; ++i) v1[i] = 5.0f * dist(rng);
+        bool ok = logosdb::l2_normalize(v1);
+        CHECK(ok);
 
-    bool ok = logosdb::l2_normalize(v1);
-    CHECK(ok);
+        float norm_sq = 0.0f;
+        for (float v : v1)
+            norm_sq += v * v;
+        CHECK(std::abs(std::sqrt(norm_sq) - 1.0f) < 1e-5f);
 
-    float norm_sq = 0.0f;
-    for (float v : v1) norm_sq += v * v;
-    CHECK(std::abs(std::sqrt(norm_sq) - 1.0f) < 1e-5f);
+        std::vector<float> v2(dim);
+        for (int i = 0; i < dim; ++i)
+            v2[i] = 3.0f * dist(rng);
+        std::vector<float> v2_orig = v2;
 
-    std::vector<float> v2(dim);
-    for (int i = 0; i < dim; ++i) v2[i] = 3.0f * dist(rng);
-    std::vector<float> v2_orig = v2;
+        std::vector<float> v2_normed = logosdb::l2_normalized(v2);
 
-    std::vector<float> v2_normed = logosdb::l2_normalized(v2);
+        for (int i = 0; i < dim; ++i)
+            CHECK(v2[i] == v2_orig[i]);
 
-    for (int i = 0; i < dim; ++i) CHECK(v2[i] == v2_orig[i]);
+        norm_sq = 0.0f;
+        for (float v : v2_normed)
+            norm_sq += v * v;
+        CHECK(std::abs(std::sqrt(norm_sq) - 1.0f) < 1e-5f);
 
-    norm_sq = 0.0f;
-    for (float v : v2_normed) norm_sq += v * v;
-    CHECK(std::abs(std::sqrt(norm_sq) - 1.0f) < 1e-5f);
+        std::vector<float> zero_vec(dim, 0.0f);
+        ok = logosdb::l2_normalize(zero_vec);
+        CHECK(!ok);
+    }
 
-    std::vector<float> zero_vec(dim, 0.0f);
-    ok = logosdb::l2_normalize(zero_vec);
-    CHECK(!ok);
-}
-
-} // TEST_SUITE("l2_normalize")
+}  // TEST_SUITE("l2_normalize")
 
 // ============================================================================
 // Test Suite: Scoring
 // ============================================================================
 
-TEST_SUITE("scoring") {
+TEST_SUITE("scoring")
+{
+    TEST_CASE("scoring: self-similarity is ~1.0")
+    {
+        std::string path = "/tmp/logosdb_test_selfscore";
+        std::filesystem::remove_all(path);
 
-TEST_CASE("scoring: self-similarity is ~1.0") {
-    std::string path = "/tmp/logosdb_test_selfscore";
-    std::filesystem::remove_all(path);
+        int dim = 64;
+        logosdb::DB db(path, {.dim = dim});
+        auto v = unit_vec(dim, 1500);
+        db.put(v, "self");
 
-    int dim = 64;
-    logosdb::DB db(path, {.dim = dim});
-    auto v = unit_vec(dim, 1500);
-    db.put(v, "self");
+        auto hits = db.search(v, 1);
+        CHECK(!hits.empty());
+        CHECK(hits[0].score > 0.99f);
 
-    auto hits = db.search(v, 1);
-    CHECK(!hits.empty());
-    CHECK(hits[0].score > 0.99f);
+        std::filesystem::remove_all(path);
+    }
 
-    std::filesystem::remove_all(path);
-}
-
-} // TEST_SUITE("scoring")
+}  // TEST_SUITE("scoring")

--- a/tools/logosdb-bench.cpp
+++ b/tools/logosdb-bench.cpp
@@ -12,36 +12,49 @@
 #include <string>
 #include <vector>
 
-static double now_ms() {
+static double now_ms()
+{
     return std::chrono::duration<double, std::milli>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
 }
 
-static std::vector<float> random_unit_vec(int dim, std::mt19937 & rng) {
+static std::vector<float> random_unit_vec(int dim, std::mt19937& rng)
+{
     std::normal_distribution<float> dist(0.0f, 1.0f);
     std::vector<float> v(dim);
     float norm = 0.0f;
-    for (int i = 0; i < dim; ++i) { v[i] = dist(rng); norm += v[i] * v[i]; }
+    for (int i = 0; i < dim; ++i)
+    {
+        v[i] = dist(rng);
+        norm += v[i] * v[i];
+    }
     norm = std::sqrt(norm);
-    if (norm > 0.0f) for (int i = 0; i < dim; ++i) v[i] /= norm;
+    if (norm > 0.0f)
+        for (int i = 0; i < dim; ++i)
+            v[i] /= norm;
     return v;
 }
 
-static float dot(const float * a, const float * b, int dim) {
+static float dot(const float* a, const float* b, int dim)
+{
     float s = 0.0f;
-    for (int i = 0; i < dim; ++i) s += a[i] * b[i];
+    for (int i = 0; i < dim; ++i)
+        s += a[i] * b[i];
     return s;
 }
 
-struct BenchResult {
-    int    n;
+struct BenchResult
+{
+    int n;
     double put_ms;
     double hnsw_search_ms;
     double brute_search_ms;
     double recall_at_k;
 };
 
-static BenchResult run_bench(int dim, int n, int n_queries, int top_k) {
+static BenchResult run_bench(int dim, int n, int n_queries, int top_k)
+{
     BenchResult result = {};
     result.n = n;
 
@@ -57,7 +70,8 @@ static BenchResult run_bench(int dim, int n, int n_queries, int top_k) {
     // Generate and insert vectors.
     std::vector<std::vector<float>> vecs(n);
     double t0 = now_ms();
-    for (int i = 0; i < n; ++i) {
+    for (int i = 0; i < n; ++i)
+    {
         vecs[i] = random_unit_vec(dim, rng);
         db.put(vecs[i], "row_" + std::to_string(i));
     }
@@ -65,30 +79,38 @@ static BenchResult run_bench(int dim, int n, int n_queries, int top_k) {
 
     // Generate queries.
     std::vector<std::vector<float>> queries(n_queries);
-    for (int q = 0; q < n_queries; ++q) {
+    for (int q = 0; q < n_queries; ++q)
+    {
         queries[q] = random_unit_vec(dim, rng);
     }
 
     // HNSW search.
     t0 = now_ms();
     std::vector<std::vector<uint64_t>> hnsw_results(n_queries);
-    for (int q = 0; q < n_queries; ++q) {
+    for (int q = 0; q < n_queries; ++q)
+    {
         auto hits = db.search(queries[q], top_k);
-        for (auto & h : hits) hnsw_results[q].push_back(h.id);
+        for (auto& h : hits)
+            hnsw_results[q].push_back(h.id);
     }
     result.hnsw_search_ms = (now_ms() - t0) / n_queries;
 
     // Brute-force search for comparison.
     t0 = now_ms();
     std::vector<std::vector<uint64_t>> brute_results(n_queries);
-    for (int q = 0; q < n_queries; ++q) {
+    for (int q = 0; q < n_queries; ++q)
+    {
         std::vector<std::pair<float, uint64_t>> scores(n);
-        for (int i = 0; i < n; ++i) {
+        for (int i = 0; i < n; ++i)
+        {
             scores[i] = {dot(queries[q].data(), vecs[i].data(), dim), (uint64_t)i};
         }
-        std::partial_sort(scores.begin(), scores.begin() + top_k, scores.end(),
-            [](auto & a, auto & b) { return a.first > b.first; });
-        for (int k = 0; k < top_k && k < n; ++k) {
+        std::partial_sort(scores.begin(),
+                          scores.begin() + top_k,
+                          scores.end(),
+                          [](auto& a, auto& b) { return a.first > b.first; });
+        for (int k = 0; k < top_k && k < n; ++k)
+        {
             brute_results[q].push_back(scores[k].second);
         }
     }
@@ -96,11 +118,18 @@ static BenchResult run_bench(int dim, int n, int n_queries, int top_k) {
 
     // Recall@k: fraction of true top-k found by HNSW.
     double total_recall = 0.0;
-    for (int q = 0; q < n_queries; ++q) {
+    for (int q = 0; q < n_queries; ++q)
+    {
         int found = 0;
-        for (auto hid : hnsw_results[q]) {
-            for (auto bid : brute_results[q]) {
-                if (hid == bid) { ++found; break; }
+        for (auto hid : hnsw_results[q])
+        {
+            for (auto bid : brute_results[q])
+            {
+                if (hid == bid)
+                {
+                    ++found;
+                    break;
+                }
             }
         }
         total_recall += (double)found / std::min(top_k, n);
@@ -111,32 +140,45 @@ static BenchResult run_bench(int dim, int n, int n_queries, int top_k) {
     return result;
 }
 
-int main(int argc, char ** argv) {
+int main(int argc, char** argv)
+{
     int dim = 2048;
     std::vector<int> counts = {1000, 10000, 100000};
     int n_queries = 50;
     int top_k = 10;
 
-    for (int i = 1; i < argc; ++i) {
-        if (!strcmp(argv[i], "--dim") && i + 1 < argc) dim = atoi(argv[++i]);
-        else if (!strcmp(argv[i], "--top-k") && i + 1 < argc) top_k = atoi(argv[++i]);
-        else if (!strcmp(argv[i], "--queries") && i + 1 < argc) n_queries = atoi(argv[++i]);
-        else if (!strcmp(argv[i], "--counts") && i + 1 < argc) {
+    for (int i = 1; i < argc; ++i)
+    {
+        if (!strcmp(argv[i], "--dim") && i + 1 < argc)
+            dim = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--top-k") && i + 1 < argc)
+            top_k = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--queries") && i + 1 < argc)
+            n_queries = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--counts") && i + 1 < argc)
+        {
             counts.clear();
-            char * tok = strtok(argv[++i], ",");
-            while (tok) { counts.push_back(atoi(tok)); tok = strtok(nullptr, ","); }
+            char* tok = strtok(argv[++i], ",");
+            while (tok)
+            {
+                counts.push_back(atoi(tok));
+                tok = strtok(nullptr, ",");
+            }
         }
     }
 
     printf("LogosDB Benchmark — dim=%d top_k=%d queries=%d\n", dim, top_k, n_queries);
-    printf("%-10s %12s %14s %14s %10s\n",
-           "N", "put(ms)", "HNSW(ms/q)", "brute(ms/q)", "recall@k");
+    printf("%-10s %12s %14s %14s %10s\n", "N", "put(ms)", "HNSW(ms/q)", "brute(ms/q)", "recall@k");
     printf("---------- ------------ -------------- -------------- ----------\n");
 
-    for (int n : counts) {
+    for (int n : counts)
+    {
         auto r = run_bench(dim, n, n_queries, top_k);
         printf("%-10d %12.1f %14.3f %14.3f %9.1f%%\n",
-               r.n, r.put_ms, r.hnsw_search_ms, r.brute_search_ms,
+               r.n,
+               r.put_ms,
+               r.hnsw_search_ms,
+               r.brute_search_ms,
                r.recall_at_k * 100.0);
     }
 
@@ -167,14 +209,16 @@ int main(int argc, char ** argv) {
 
             std::mt19937 rng(42);
             double t0 = now_ms();
-            for (int i = 0; i < batch_n; ++i) {
+            for (int i = 0; i < batch_n; ++i)
+            {
                 auto v = random_unit_vec(batch_dim, rng);
                 db.put(v, "row_" + std::to_string(i));
             }
             individual_ms = now_ms() - t0;
 
             printf("Individual puts:  %.1f ms (%.1f vectors/sec)\n",
-                   individual_ms, batch_n / (individual_ms / 1000.0));
+                   individual_ms,
+                   batch_n / (individual_ms / 1000.0));
         }
         std::filesystem::remove_all(tmp1);
 
@@ -193,7 +237,8 @@ int main(int argc, char ** argv) {
             std::vector<std::string> texts;
             texts.reserve(batch_n);
 
-            for (int i = 0; i < batch_n; ++i) {
+            for (int i = 0; i < batch_n; ++i)
+            {
                 auto v = random_unit_vec(batch_dim, rng);
                 embeddings.insert(embeddings.end(), v.begin(), v.end());
                 texts.push_back("row_" + std::to_string(i));
@@ -204,7 +249,8 @@ int main(int argc, char ** argv) {
             batch_ms = now_ms() - t0;
 
             printf("Batch put:        %.1f ms (%.1f vectors/sec)\n",
-                   batch_ms, batch_n / (batch_ms / 1000.0));
+                   batch_ms,
+                   batch_n / (batch_ms / 1000.0));
         }
         std::filesystem::remove_all(tmp2);
 

--- a/tools/logosdb-cli.cpp
+++ b/tools/logosdb-cli.cpp
@@ -4,27 +4,30 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <memory>
 
 // Base64 encoding/decoding for import/export
 static const char* BASE64_CHARS =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-static std::string base64_encode(const float* data, size_t n_floats) {
+static std::string base64_encode(const float* data, size_t n_floats)
+{
     const unsigned char* bytes = reinterpret_cast<const unsigned char*>(data);
     size_t len = n_floats * sizeof(float);
     std::string ret;
     ret.reserve(((len + 2) / 3) * 4);
 
-    for (size_t i = 0; i < len; i += 3) {
+    for (size_t i = 0; i < len; i += 3)
+    {
         unsigned char b[3] = {0, 0, 0};
         size_t n = 0;
-        for (size_t j = 0; j < 3 && i + j < len; ++j) {
+        for (size_t j = 0; j < 3 && i + j < len; ++j)
+        {
             b[j] = bytes[i + j];
             n++;
         }
@@ -41,7 +44,8 @@ static std::string base64_encode(const float* data, size_t n_floats) {
     return ret;
 }
 
-static std::vector<float> base64_decode(const std::string& encoded, int dim) {
+static std::vector<float> base64_decode(const std::string& encoded, int dim)
+{
     std::vector<float> result;
     std::vector<unsigned char> bytes;
 
@@ -51,48 +55,64 @@ static std::vector<float> base64_decode(const std::string& encoded, int dim) {
 
     size_t len = encoded.size();
 
-    auto find_char = [](char c) -> int {
-        if (c >= 'A' && c <= 'Z') return c - 'A';
-        if (c >= 'a' && c <= 'z') return c - 'a' + 26;
-        if (c >= '0' && c <= '9') return c - '0' + 52;
-        if (c == '+') return 62;
-        if (c == '/') return 63;
-        if (c == '=') return -2;  // padding
+    auto find_char = [](char c) -> int
+    {
+        if (c >= 'A' && c <= 'Z')
+            return c - 'A';
+        if (c >= 'a' && c <= 'z')
+            return c - 'a' + 26;
+        if (c >= '0' && c <= '9')
+            return c - '0' + 52;
+        if (c == '+')
+            return 62;
+        if (c == '/')
+            return 63;
+        if (c == '=')
+            return -2;  // padding
         return -1;
     };
 
-    for (size_t i = 0; i < len; i += 4) {
-        if (i + 3 >= len) break;
+    for (size_t i = 0; i < len; i += 4)
+    {
+        if (i + 3 >= len)
+            break;
 
         int b[4] = {-1, -1, -1, -1};
-        for (int j = 0; j < 4 && i + j < len; ++j) {
+        for (int j = 0; j < 4 && i + j < len; ++j)
+        {
             b[j] = find_char(encoded[i + j]);
         }
 
         // Skip if we hit invalid characters
-        if (b[0] < 0 || b[0] == -2) break;
-        if (b[1] < 0 || b[1] == -2) break;
+        if (b[0] < 0 || b[0] == -2)
+            break;
+        if (b[1] < 0 || b[1] == -2)
+            break;
 
         unsigned char o0 = (b[0] << 2) | (b[1] >> 4);
         bytes.push_back(o0);
 
-        if (b[2] >= 0) {
+        if (b[2] >= 0)
+        {
             unsigned char o1 = ((b[1] & 0x0F) << 4) | (b[2] >> 2);
             bytes.push_back(o1);
         }
-        if (b[3] >= 0) {
+        if (b[3] >= 0)
+        {
             unsigned char o2 = ((b[2] & 0x03) << 6) | b[3];
             bytes.push_back(o2);
         }
     }
 
     // Convert bytes to floats - ensure we have enough bytes
-    if (bytes.size() < expected_bytes) {
+    if (bytes.size() < expected_bytes)
+    {
         return result;  // Return empty if not enough data
     }
 
     result.reserve(dim);
-    for (int i = 0; i < dim; i++) {
+    for (int i = 0; i < dim; i++)
+    {
         float f;
         std::memcpy(&f, &bytes[i * sizeof(float)], sizeof(float));
         result.push_back(f);
@@ -102,109 +122,142 @@ static std::vector<float> base64_decode(const std::string& encoded, int dim) {
 }
 
 // Storage header structure (from storage.h)
-struct StorageHeader {
-    uint32_t magic    = 0x4C4F474F;  // "LOGO"
-    uint32_t version  = 1;
-    uint32_t dim      = 0;
+struct StorageHeader
+{
+    uint32_t magic = 0x4C4F474F;  // "LOGO"
+    uint32_t version = 1;
+    uint32_t dim = 0;
     uint32_t reserved = 0;
-    uint64_t n_rows   = 0;
+    uint64_t n_rows = 0;
     uint64_t reserved2 = 0;
 };
 
-static bool read_dim_from_header(const char* path, int& dim) {
+static bool read_dim_from_header(const char* path, int& dim)
+{
     FILE* f = fopen(path, "rb");
-    if (!f) return false;
+    if (!f)
+        return false;
     StorageHeader hdr;
     size_t n = fread(&hdr, 1, sizeof(hdr), f);
     fclose(f);
-    if (n != sizeof(hdr)) return false;
-    if (hdr.magic != 0x4C4F474FU) return false;
+    if (n != sizeof(hdr))
+        return false;
+    if (hdr.magic != 0x4C4F474FU)
+        return false;
     dim = (int)hdr.dim;
     return dim > 0;
 }
 
-static std::vector<float> read_binary_vec(const char* path, int dim) {
+static std::vector<float> read_binary_vec(const char* path, int dim)
+{
     std::vector<float> v(dim);
     FILE* f = fopen(path, "rb");
-    if (!f) return {};
+    if (!f)
+        return {};
     size_t n = fread(v.data(), sizeof(float), dim, f);
     fclose(f);
-    if ((int)n != dim) return {};
+    if ((int)n != dim)
+        return {};
     return v;
 }
 
-static void print_version() {
+static void print_version()
+{
     printf("logosdb-cli version %s\n", LOGOSDB_VERSION_STRING);
 }
 
-static void print_usage(const char* prog) {
-    printf(
-        "Usage: %s <command> [options]\n"
-        "\n"
-        "Commands:\n"
-        "  info <db-path> [--json]           Show database info (dim read from file)\n"
-        "  put <db-path> [options]           Insert a vector\n"
-        "  search <db-path> [options]        Search for similar vectors\n"
-        "  export <db-path> [--output FILE]  Export DB to JSONL with base64 vectors\n"
-        "  import <db-path> [--input FILE]   Import from JSONL\n"
-        "\n"
-        "Global Options:\n"
-        "  --version                         Show version and exit\n"
-        "  --help, -h                        Show this help and exit\n"
-        "\n"
-        "Put Options:\n"
-        "  --dim N                           Vector dimension (required for new DB)\n"
-        "  --text TEXT                       Text metadata\n"
-        "  --ts TIMESTAMP                    ISO 8601 timestamp\n"
-        "  --embedding-file FILE             Binary float32 vector file\n"
-        "\n"
-        "Search Options:\n"
-        "  --dim N                           Vector dimension (required for new DB)\n"
-        "  --query-file FILE                 Binary float32 query vector\n"
-        "  --query-id ID                     Use existing vector as query\n"
-        "  --top-k N                         Number of results (default: 5)\n"
-        "  --ts-from TIMESTAMP               Filter from timestamp (inclusive)\n"
-        "  --ts-to TIMESTAMP                 Filter to timestamp (inclusive)\n"
-        "  --json                            Output results as JSON\n"
-        "\n"
-        "Export Options:\n"
-        "  --output FILE                     Output file (default: stdout)\n"
-        "  --json                            Same as default (JSONL output)\n"
-        "\n"
-        "Import Options:\n"
-        "  --dim N                           Vector dimension (required for new DB)\n"
-        "  --input FILE                      Input JSONL file (default: stdin)\n"
-        "\n"
-        "Examples:\n"
-        "  %s info /tmp/mydb                 Show database info\n"
-        "  %s info /tmp/mydb --json          Show info as JSON\n"
-        "  %s put /tmp/mydb --dim 128 --text \"hello\" --embedding-file vec.bin\n"
-        "  %s search /tmp/mydb --dim 128 --query-file query.bin --top-k 10\n"
-        "  %s search /tmp/mydb --dim 128 --query-id 0 --ts-from 2025-01-01T00:00:00Z\n"
-        "  %s export /tmp/mydb --output backup.jsonl\n"
-        "  %s import /tmp/newdb --dim 128 --input backup.jsonl\n"
-        , prog, prog, prog, prog, prog, prog, prog, prog
-    );
+static void print_usage(const char* prog)
+{
+    printf("Usage: %s <command> [options]\n"
+           "\n"
+           "Commands:\n"
+           "  info <db-path> [--json]           Show database info (dim read from file)\n"
+           "  put <db-path> [options]           Insert a vector\n"
+           "  search <db-path> [options]        Search for similar vectors\n"
+           "  export <db-path> [--output FILE]  Export DB to JSONL with base64 vectors\n"
+           "  import <db-path> [--input FILE]   Import from JSONL\n"
+           "\n"
+           "Global Options:\n"
+           "  --version                         Show version and exit\n"
+           "  --help, -h                        Show this help and exit\n"
+           "\n"
+           "Put Options:\n"
+           "  --dim N                           Vector dimension (required for new DB)\n"
+           "  --text TEXT                       Text metadata\n"
+           "  --ts TIMESTAMP                    ISO 8601 timestamp\n"
+           "  --embedding-file FILE             Binary float32 vector file\n"
+           "\n"
+           "Search Options:\n"
+           "  --dim N                           Vector dimension (required for new DB)\n"
+           "  --query-file FILE                 Binary float32 query vector\n"
+           "  --query-id ID                     Use existing vector as query\n"
+           "  --top-k N                         Number of results (default: 5)\n"
+           "  --ts-from TIMESTAMP               Filter from timestamp (inclusive)\n"
+           "  --ts-to TIMESTAMP                 Filter to timestamp (inclusive)\n"
+           "  --json                            Output results as JSON\n"
+           "\n"
+           "Export Options:\n"
+           "  --output FILE                     Output file (default: stdout)\n"
+           "  --json                            Same as default (JSONL output)\n"
+           "\n"
+           "Import Options:\n"
+           "  --dim N                           Vector dimension (required for new DB)\n"
+           "  --input FILE                      Input JSONL file (default: stdin)\n"
+           "\n"
+           "Examples:\n"
+           "  %s info /tmp/mydb                 Show database info\n"
+           "  %s info /tmp/mydb --json          Show info as JSON\n"
+           "  %s put /tmp/mydb --dim 128 --text \"hello\" --embedding-file vec.bin\n"
+           "  %s search /tmp/mydb --dim 128 --query-file query.bin --top-k 10\n"
+           "  %s search /tmp/mydb --dim 128 --query-id 0 --ts-from 2025-01-01T00:00:00Z\n"
+           "  %s export /tmp/mydb --output backup.jsonl\n"
+           "  %s import /tmp/newdb --dim 128 --input backup.jsonl\n",
+           prog,
+           prog,
+           prog,
+           prog,
+           prog,
+           prog,
+           prog,
+           prog);
 }
 
-static void print_cmd_help(const char* cmd) {
-    if (strcmp(cmd, "info") == 0) {
+static void print_cmd_help(const char* cmd)
+{
+    if (strcmp(cmd, "info") == 0)
+    {
         printf("Usage: logosdb-cli info <db-path> [--json]\n\nShow database information.\n");
-    } else if (strcmp(cmd, "put") == 0) {
-        printf("Usage: logosdb-cli put <db-path> [options]\n\nOptions:\n  --dim N\n  --text TEXT\n  --ts TIMESTAMP\n  --embedding-file FILE\n");
-    } else if (strcmp(cmd, "search") == 0) {
-        printf("Usage: logosdb-cli search <db-path> [options]\n\nOptions:\n  --dim N\n  --query-file FILE\n  --query-id ID\n  --top-k N\n  --ts-from TIMESTAMP\n  --ts-to TIMESTAMP\n  --json\n");
-    } else if (strcmp(cmd, "export") == 0) {
-        printf("Usage: logosdb-cli export <db-path> [--output FILE]\n\nExport database to JSONL.\n");
-    } else if (strcmp(cmd, "import") == 0) {
-        printf("Usage: logosdb-cli import <db-path> [options]\n\nOptions:\n  --dim N (required for new DB)\n  --input FILE\n");
-    } else {
+    }
+    else if (strcmp(cmd, "put") == 0)
+    {
+        printf("Usage: logosdb-cli put <db-path> [options]\n\nOptions:\n  --dim N\n  --text TEXT\n "
+               " --ts TIMESTAMP\n  --embedding-file FILE\n");
+    }
+    else if (strcmp(cmd, "search") == 0)
+    {
+        printf("Usage: logosdb-cli search <db-path> [options]\n\nOptions:\n  --dim N\n  "
+               "--query-file FILE\n  --query-id ID\n  --top-k N\n  --ts-from TIMESTAMP\n  --ts-to "
+               "TIMESTAMP\n  --json\n");
+    }
+    else if (strcmp(cmd, "export") == 0)
+    {
+        printf(
+            "Usage: logosdb-cli export <db-path> [--output FILE]\n\nExport database to JSONL.\n");
+    }
+    else if (strcmp(cmd, "import") == 0)
+    {
+        printf("Usage: logosdb-cli import <db-path> [options]\n\nOptions:\n  --dim N (required for "
+               "new DB)\n  --input FILE\n");
+    }
+    else
+    {
         printf("Unknown command: %s\n", cmd);
     }
 }
 
 // Command-line argument structure
-struct Args {
+struct Args
+{
     std::string cmd;
     std::string db_path;
     int dim = 0;
@@ -223,93 +276,127 @@ struct Args {
     bool version = false;
 };
 
-static Args parse_args(int argc, char** argv) {
+static Args parse_args(int argc, char** argv)
+{
     Args args;
-    if (argc < 2) return args;
+    if (argc < 2)
+        return args;
 
     // Check for global --version or --help first
-    for (int i = 1; i < argc; ++i) {
-        if (strcmp(argv[i], "--version") == 0) {
+    for (int i = 1; i < argc; ++i)
+    {
+        if (strcmp(argv[i], "--version") == 0)
+        {
             args.version = true;
             return args;
         }
-        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
+        {
             args.help = true;
-            if (i + 1 < argc && argv[i + 1][0] != '-') {
+            if (i + 1 < argc && argv[i + 1][0] != '-')
+            {
                 args.cmd = argv[i + 1];  // --help <cmd>
             }
             return args;
         }
     }
 
-    if (argc < 3) return args;
+    if (argc < 3)
+        return args;
 
     args.cmd = argv[1];
     args.db_path = argv[2];
 
-    for (int i = 3; i < argc; ++i) {
-        if (!strcmp(argv[i], "--dim") && i + 1 < argc) {
+    for (int i = 3; i < argc; ++i)
+    {
+        if (!strcmp(argv[i], "--dim") && i + 1 < argc)
+        {
             long v = strtol(argv[++i], nullptr, 10);
             args.dim = (v > 0 && v <= 65536) ? (int)v : 0;
         }
-        else if (!strcmp(argv[i], "--top-k") && i + 1 < argc) {
+        else if (!strcmp(argv[i], "--top-k") && i + 1 < argc)
+        {
             long v = strtol(argv[++i], nullptr, 10);
             args.top_k = (v > 0 && v <= 10000) ? (int)v : 5;
         }
-        else if (!strcmp(argv[i], "--text") && i + 1 < argc) args.text = argv[++i];
-        else if (!strcmp(argv[i], "--ts") && i + 1 < argc) args.ts = argv[++i];
-        else if (!strcmp(argv[i], "--embedding-file") && i + 1 < argc) args.emb_file = argv[++i];
-        else if (!strcmp(argv[i], "--query-file") && i + 1 < argc) args.query_file = argv[++i];
-        else if (!strcmp(argv[i], "--query-id") && i + 1 < argc) {
+        else if (!strcmp(argv[i], "--text") && i + 1 < argc)
+            args.text = argv[++i];
+        else if (!strcmp(argv[i], "--ts") && i + 1 < argc)
+            args.ts = argv[++i];
+        else if (!strcmp(argv[i], "--embedding-file") && i + 1 < argc)
+            args.emb_file = argv[++i];
+        else if (!strcmp(argv[i], "--query-file") && i + 1 < argc)
+            args.query_file = argv[++i];
+        else if (!strcmp(argv[i], "--query-id") && i + 1 < argc)
+        {
             long long v = strtoll(argv[++i], nullptr, 10);
             args.query_id = (v >= 0) ? (uint64_t)v : UINT64_MAX;
         }
-        else if (!strcmp(argv[i], "--ts-from") && i + 1 < argc) args.ts_from = argv[++i];
-        else if (!strcmp(argv[i], "--ts-to") && i + 1 < argc) args.ts_to = argv[++i];
-        else if (!strcmp(argv[i], "--output") && i + 1 < argc) args.output_file = argv[++i];
-        else if (!strcmp(argv[i], "--input") && i + 1 < argc) args.input_file = argv[++i];
-        else if (!strcmp(argv[i], "--json")) args.json = true;
-        else if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) args.help = true;
+        else if (!strcmp(argv[i], "--ts-from") && i + 1 < argc)
+            args.ts_from = argv[++i];
+        else if (!strcmp(argv[i], "--ts-to") && i + 1 < argc)
+            args.ts_to = argv[++i];
+        else if (!strcmp(argv[i], "--output") && i + 1 < argc)
+            args.output_file = argv[++i];
+        else if (!strcmp(argv[i], "--input") && i + 1 < argc)
+            args.input_file = argv[++i];
+        else if (!strcmp(argv[i], "--json"))
+            args.json = true;
+        else if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h"))
+            args.help = true;
     }
 
     return args;
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
     Args args = parse_args(argc, argv);
 
-    if (args.version) {
+    if (args.version)
+    {
         print_version();
         return 0;
     }
 
-    if (args.help) {
-        if (!args.cmd.empty()) {
+    if (args.help)
+    {
+        if (!args.cmd.empty())
+        {
             print_cmd_help(args.cmd.c_str());
-        } else {
+        }
+        else
+        {
             print_usage(argv[0]);
         }
         return 0;
     }
 
-    if (args.cmd.empty() || args.db_path.empty()) {
+    if (args.cmd.empty() || args.db_path.empty())
+    {
         print_usage(argv[0]);
         return 1;
     }
 
     // Try to read dim from existing database for info command
-    if (args.cmd == "info" && args.dim == 0) {
+    if (args.cmd == "info" && args.dim == 0)
+    {
         std::string vec_path = args.db_path + "/vectors.bin";
-        if (!read_dim_from_header(vec_path.c_str(), args.dim)) {
-            fprintf(stderr, "error: cannot read dim from %s (use --dim for new DB)\n", vec_path.c_str());
+        if (!read_dim_from_header(vec_path.c_str(), args.dim))
+        {
+            fprintf(stderr,
+                    "error: cannot read dim from %s (use --dim for new DB)\n",
+                    vec_path.c_str());
             return 1;
         }
     }
 
     // For import, dim may be optional if DB exists
-    if (args.cmd == "import" && args.dim == 0) {
+    if (args.cmd == "import" && args.dim == 0)
+    {
         std::string vec_path = args.db_path + "/vectors.bin";
-        if (!read_dim_from_header(vec_path.c_str(), args.dim)) {
+        if (!read_dim_from_header(vec_path.c_str(), args.dim))
+        {
             fprintf(stderr, "error: --dim required for new database\n");
             return 1;
         }
@@ -317,10 +404,13 @@ int main(int argc, char** argv) {
 
     // For other commands, dim is required if DB doesn't exist
     // For export, we also need to read the dim from the file
-    if (args.dim == 0) {
+    if (args.dim == 0)
+    {
         std::string vec_path = args.db_path + "/vectors.bin";
-        if (!read_dim_from_header(vec_path.c_str(), args.dim)) {
-            if (args.cmd != "export") {
+        if (!read_dim_from_header(vec_path.c_str(), args.dim))
+        {
+            if (args.cmd != "export")
+            {
                 fprintf(stderr, "error: --dim required (1..65536)\n");
                 return 1;
             }
@@ -332,11 +422,13 @@ int main(int argc, char** argv) {
 
     char* err = nullptr;
     logosdb_options_t* opts = logosdb_options_create();
-    if (args.dim > 0) logosdb_options_set_dim(opts, args.dim);
+    if (args.dim > 0)
+        logosdb_options_set_dim(opts, args.dim);
     logosdb_t* db = logosdb_open(args.db_path.c_str(), opts, &err);
     logosdb_options_destroy(opts);
 
-    if (!db) {
+    if (!db)
+    {
         fprintf(stderr, "error: %s\n", err ? err : "unknown");
         free(err);
         return 1;
@@ -344,128 +436,181 @@ int main(int argc, char** argv) {
 
     int rc = 0;
 
-    if (args.cmd == "info") {
-        if (args.json) {
+    if (args.cmd == "info")
+    {
+        if (args.json)
+        {
             printf("{\n");
             printf("  \"path\": \"%s\",\n", args.db_path.c_str());
             printf("  \"dim\": %d,\n", logosdb_dim(db));
             printf("  \"count\": %zu,\n", logosdb_count(db));
             printf("  \"count_live\": %zu\n", logosdb_count_live(db));
             printf("}\n");
-        } else {
+        }
+        else
+        {
             printf("path       : %s\n", args.db_path.c_str());
             printf("dim        : %d\n", logosdb_dim(db));
             printf("count      : %zu\n", logosdb_count(db));
             printf("count_live : %zu\n", logosdb_count_live(db));
         }
     }
-    else if (args.cmd == "put") {
-        if (!args.emb_file) {
+    else if (args.cmd == "put")
+    {
+        if (!args.emb_file)
+        {
             fprintf(stderr, "error: --embedding-file required\n");
             rc = 1;
             goto done;
         }
         auto vec = read_binary_vec(args.emb_file, logosdb_dim(db));
-        if ((int)vec.size() != logosdb_dim(db)) {
-            fprintf(stderr, "error: could not read embedding (expected %d floats)\n", logosdb_dim(db));
+        if ((int)vec.size() != logosdb_dim(db))
+        {
+            fprintf(
+                stderr, "error: could not read embedding (expected %d floats)\n", logosdb_dim(db));
             rc = 1;
             goto done;
         }
         uint64_t id = logosdb_put(db, vec.data(), logosdb_dim(db), args.text, args.ts, &err);
-        if (id == UINT64_MAX) {
+        if (id == UINT64_MAX)
+        {
             fprintf(stderr, "error: %s\n", err ? err : "unknown");
             free(err);
             rc = 1;
-        } else {
-            if (args.json) {
+        }
+        else
+        {
+            if (args.json)
+            {
                 printf("{\"id\": %llu}\n", (unsigned long long)id);
-            } else {
+            }
+            else
+            {
                 printf("put id=%llu\n", (unsigned long long)id);
             }
         }
     }
-    else if (args.cmd == "search") {
+    else if (args.cmd == "search")
+    {
         std::vector<float> qvec;
 
-        if (args.query_file) {
+        if (args.query_file)
+        {
             qvec = read_binary_vec(args.query_file, logosdb_dim(db));
-            if ((int)qvec.size() != logosdb_dim(db)) {
-                fprintf(stderr, "error: could not read query (expected %d floats)\n", logosdb_dim(db));
+            if ((int)qvec.size() != logosdb_dim(db))
+            {
+                fprintf(
+                    stderr, "error: could not read query (expected %d floats)\n", logosdb_dim(db));
                 rc = 1;
                 goto done;
             }
-        } else if (args.query_id != UINT64_MAX) {
+        }
+        else if (args.query_id != UINT64_MAX)
+        {
             // Use existing vector as query
             const float* raw = logosdb_raw_vectors(db, nullptr, nullptr);
-            if (!raw || args.query_id >= logosdb_count(db)) {
-                fprintf(stderr, "error: invalid query-id %llu\n", (unsigned long long)args.query_id);
+            if (!raw || args.query_id >= logosdb_count(db))
+            {
+                fprintf(
+                    stderr, "error: invalid query-id %llu\n", (unsigned long long)args.query_id);
                 rc = 1;
                 goto done;
             }
             qvec.resize(logosdb_dim(db));
-            std::memcpy(qvec.data(), raw + args.query_id * logosdb_dim(db), logosdb_dim(db) * sizeof(float));
-        } else {
+            std::memcpy(qvec.data(),
+                        raw + args.query_id * logosdb_dim(db),
+                        logosdb_dim(db) * sizeof(float));
+        }
+        else
+        {
             fprintf(stderr, "error: --query-file or --query-id required\n");
             rc = 1;
             goto done;
         }
 
         logosdb_search_result_t* res;
-        if (args.ts_from || args.ts_to) {
+        if (args.ts_from || args.ts_to)
+        {
             int candidate_k = args.top_k * 10;
-            res = logosdb_search_ts_range(db, qvec.data(), logosdb_dim(db), args.top_k,
-                                         args.ts_from, args.ts_to, candidate_k, &err);
-        } else {
+            res = logosdb_search_ts_range(db,
+                                          qvec.data(),
+                                          logosdb_dim(db),
+                                          args.top_k,
+                                          args.ts_from,
+                                          args.ts_to,
+                                          candidate_k,
+                                          &err);
+        }
+        else
+        {
             res = logosdb_search(db, qvec.data(), logosdb_dim(db), args.top_k, &err);
         }
 
-        if (!res) {
+        if (!res)
+        {
             fprintf(stderr, "error: %s\n", err ? err : "unknown");
             free(err);
             rc = 1;
-        } else {
+        }
+        else
+        {
             int n = logosdb_result_count(res);
-            if (args.json) {
+            if (args.json)
+            {
                 printf("[\n");
-                for (int i = 0; i < n; ++i) {
+                for (int i = 0; i < n; ++i)
+                {
                     printf("  {\n");
                     printf("    \"rank\": %d,\n", i);
                     printf("    \"id\": %llu,\n", (unsigned long long)logosdb_result_id(res, i));
                     printf("    \"score\": %.6f", logosdb_result_score(res, i));
                     const char* t = logosdb_result_text(res, i);
                     const char* tts = logosdb_result_timestamp(res, i);
-                    if (t) {
+                    if (t)
+                    {
                         printf(",\n    \"text\": \"%s\"", t);
-                        if (tts) {
+                        if (tts)
+                        {
                             printf(",\n    \"timestamp\": \"%s\"", tts);
                         }
-                    } else if (tts) {
+                    }
+                    else if (tts)
+                    {
                         printf(",\n    \"timestamp\": \"%s\"", tts);
                     }
                     printf("\n  }%s\n", (i < n - 1) ? "," : "");
                 }
                 printf("]\n");
-            } else {
+            }
+            else
+            {
                 printf("results: %d\n", n);
-                for (int i = 0; i < n; ++i) {
-                    printf("  #%d id=%llu score=%.6f", i,
+                for (int i = 0; i < n; ++i)
+                {
+                    printf("  #%d id=%llu score=%.6f",
+                           i,
                            (unsigned long long)logosdb_result_id(res, i),
                            logosdb_result_score(res, i));
                     const char* t = logosdb_result_text(res, i);
-                    if (t) printf(" text=\"%s\"", t);
+                    if (t)
+                        printf(" text=\"%s\"", t);
                     const char* tts = logosdb_result_timestamp(res, i);
-                    if (tts) printf(" ts=%s", tts);
+                    if (tts)
+                        printf(" ts=%s", tts);
                     printf("\n");
                 }
             }
             logosdb_result_free(res);
         }
     }
-    else if (args.cmd == "export") {
+    else if (args.cmd == "export")
+    {
         FILE* out = stdout;
-        if (args.output_file) {
+        if (args.output_file)
+        {
             out = fopen(args.output_file, "w");
-            if (!out) {
+            if (!out)
+            {
                 fprintf(stderr, "error: cannot open output file %s\n", args.output_file);
                 rc = 1;
                 goto done;
@@ -476,39 +621,52 @@ int main(int argc, char** argv) {
         int dim = 0;
         const float* raw = logosdb_raw_vectors(db, &n_rows, &dim);
 
-        for (size_t i = 0; i < n_rows; ++i) {
+        for (size_t i = 0; i < n_rows; ++i)
+        {
             // Get metadata
             char tmp_err[256];
             logosdb_search_result_t* tmp_res = logosdb_search(db, raw + i * dim, dim, 1, nullptr);
             const char* text = "";
             const char* ts = "";
-            if (tmp_res) {
+            if (tmp_res)
+            {
                 text = logosdb_result_text(tmp_res, 0);
-                if (!text) text = "";
+                if (!text)
+                    text = "";
                 ts = logosdb_result_timestamp(tmp_res, 0);
-                if (!ts) ts = "";
+                if (!ts)
+                    ts = "";
             }
 
             // Encode vector as base64
             std::string b64 = base64_encode(raw + i * dim, dim);
 
             // Output JSONL
-            fprintf(out, "{\"id\": %zu, \"vector\": \"%s\", \"text\": \"%s\", \"timestamp\": \"%s\"}\n",
-                    i, b64.c_str(), text, ts);
+            fprintf(out,
+                    "{\"id\": %zu, \"vector\": \"%s\", \"text\": \"%s\", \"timestamp\": \"%s\"}\n",
+                    i,
+                    b64.c_str(),
+                    text,
+                    ts);
 
-            if (tmp_res) logosdb_result_free(tmp_res);
+            if (tmp_res)
+                logosdb_result_free(tmp_res);
         }
 
-        if (args.output_file) {
+        if (args.output_file)
+        {
             fclose(out);
             printf("Exported %zu rows to %s\n", n_rows, args.output_file);
         }
     }
-    else if (args.cmd == "import") {
+    else if (args.cmd == "import")
+    {
         FILE* in = stdin;
-        if (args.input_file) {
+        if (args.input_file)
+        {
             in = fopen(args.input_file, "r");
-            if (!in) {
+            if (!in)
+            {
                 fprintf(stderr, "error: cannot open input file %s\n", args.input_file);
                 rc = 1;
                 goto done;
@@ -518,23 +676,29 @@ int main(int argc, char** argv) {
         size_t imported = 0;
         size_t lines_read = 0;
         char line[65536];
-        while (fgets(line, sizeof(line), in)) {
+        while (fgets(line, sizeof(line), in))
+        {
             lines_read++;
 
             // Extract vector (base64)
             char* vec_field = strstr(line, "\"vector\"");
-            if (!vec_field) continue;
+            if (!vec_field)
+                continue;
 
             // Find the value after "vector":
             char* vec_start = strchr(vec_field, ':');
-            if (!vec_start) continue;
+            if (!vec_start)
+                continue;
             vec_start++;
-            while (*vec_start == ' ') vec_start++;
-            if (*vec_start != '"') continue;
+            while (*vec_start == ' ')
+                vec_start++;
+            if (*vec_start != '"')
+                continue;
             vec_start++;  // skip opening quote
 
             char* vec_end = strchr(vec_start, '"');
-            if (!vec_end) continue;
+            if (!vec_end)
+                continue;
 
             // Temporarily null-terminate to extract
             *vec_end = '\0';
@@ -542,7 +706,8 @@ int main(int argc, char** argv) {
             *vec_end = '"';
 
             auto vec = base64_decode(b64, logosdb_dim(db));
-            if ((int)vec.size() != logosdb_dim(db)) {
+            if ((int)vec.size() != logosdb_dim(db))
+            {
                 fprintf(stderr, "warning: skipping row with wrong dimension\n");
                 continue;
             }
@@ -550,15 +715,20 @@ int main(int argc, char** argv) {
             // Extract text
             std::string text;
             char* text_field = strstr(line, "\"text\"");
-            if (text_field) {
+            if (text_field)
+            {
                 char* text_start = strchr(text_field, ':');
-                if (text_start) {
+                if (text_start)
+                {
                     text_start++;
-                    while (*text_start == ' ') text_start++;
-                    if (*text_start == '"') {
+                    while (*text_start == ' ')
+                        text_start++;
+                    if (*text_start == '"')
+                    {
                         text_start++;
                         char* text_end = strchr(text_start, '"');
-                        if (text_end) {
+                        if (text_end)
+                        {
                             *text_end = '\0';
                             text = text_start;
                             *text_end = '"';
@@ -570,15 +740,20 @@ int main(int argc, char** argv) {
             // Extract timestamp
             std::string ts;
             char* ts_field = strstr(line, "\"timestamp\"");
-            if (ts_field) {
+            if (ts_field)
+            {
                 char* ts_start = strchr(ts_field, ':');
-                if (ts_start) {
+                if (ts_start)
+                {
                     ts_start++;
-                    while (*ts_start == ' ') ts_start++;
-                    if (*ts_start == '"') {
+                    while (*ts_start == ' ')
+                        ts_start++;
+                    if (*ts_start == '"')
+                    {
                         ts_start++;
                         char* ts_end = strchr(ts_start, '"');
-                        if (ts_end) {
+                        if (ts_end)
+                        {
                             *ts_end = '\0';
                             ts = ts_start;
                             *ts_end = '"';
@@ -588,13 +763,20 @@ int main(int argc, char** argv) {
             }
 
             // Insert
-            uint64_t id = logosdb_put(db, vec.data(), logosdb_dim(db),
-                                     text.empty() ? nullptr : text.c_str(),
-                                     ts.empty() ? nullptr : ts.c_str(), &err);
-            if (id != UINT64_MAX) {
+            uint64_t id = logosdb_put(db,
+                                      vec.data(),
+                                      logosdb_dim(db),
+                                      text.empty() ? nullptr : text.c_str(),
+                                      ts.empty() ? nullptr : ts.c_str(),
+                                      &err);
+            if (id != UINT64_MAX)
+            {
                 imported++;
-            } else {
-                if (err) {
+            }
+            else
+            {
+                if (err)
+                {
                     fprintf(stderr, "warning: insert failed: %s\n", err);
                     free(err);
                     err = nullptr;
@@ -602,10 +784,12 @@ int main(int argc, char** argv) {
             }
         }
 
-        if (args.input_file) fclose(in);
+        if (args.input_file)
+            fclose(in);
         printf("Imported %zu rows\n", imported);
     }
-    else {
+    else
+    {
         fprintf(stderr, "error: unknown command: %s\n", args.cmd.c_str());
         print_usage(argv[0]);
         rc = 1;


### PR DESCRIPTION
## Summary

Add formatting and linting configuration files for consistent code style across the project.

Closes #12

## Changes

- [x] Add .clang-format: LLVM-based style with 4-space indent, Allman braces, 100 col limit
- [x] Add .clang-tidy: Conservative rule set (bugprone, performance, readability, cppcoreguidelines, modernize)
- [x] Add .editorconfig: UTF-8, LF endings, language-specific indentation rules
- [x] Add format-check CI job on ubuntu-latest
- [x] Update CONTRIBUTING.md with formatting tool usage

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing

- [x] Manual testing performed

Tested locally on macOS with clang-format 22.1.5 and clang-tidy from LLVM 22.1.4:
- Verified `find src include tests tools -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run -Werror` detects violations (exit code 1)
- Verified `clang-tidy -p build src/*.cpp` runs successfully with compile_commands.json
- Fixed invalid config options discovered during testing:
  - Removed `AllowAllParametersOfDeclarationOnANextLine` from .clang-format (invalid key)
  - Removed `AnalyzeTemporaryDtors` from .clang-tidy (invalid key)

## Checklist

- [x] Code compiles without warnings on GCC and Clang (no code changes)
- [ ] Tests pass — N/A, no code changes
- [ ] Benchmarks run — N/A
- [ ] CHANGELOG updated — N/A, contributor tooling only
- [x] Documentation updated (CONTRIBUTING.md)
- [x] PR title follows conventional commit style (`build:`)

## Additional Notes

**Design decisions:**
- Used LLVM-based .clang-format with minimal tweaks to match existing codebase conventions (4-space indent, Allman braces)
- clang-tidy runs in report-only mode initially (`continue-on-error: true`) to avoid blocking PRs while issues are addressed
- .editorconfig covers all project file types (C/C++, Python, YAML, Markdown, shell)

**Trade-offs:**
- Existing code has formatting violations; first-time contributors may see CI failures until codebase is reformatted
- clang-tidy generates ~4000 warnings on existing code; kept non-blocking until issues are triaged

**Usage for contributors:**
```bash
# Format a file before committing
clang-format -i src/yourfile.cpp

# Check for common issues
cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
clang-tidy -p build src/yourfile.cpp