### PR TITLE
fix: harden MCP/CLI inputs, add sanitizer CI and JSON fuzz harness (v0.7.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,35 +79,6 @@ jobs:
           rm -rf /tmp/ci-smoke-db
           ./logosdb-cli info /tmp/ci-smoke-db --dim 16
 
-  # Address + UndefinedBehavior sanitizers (Clang, Linux; hnswlib excluded — see ci/sanitizer_ignorelist.txt)
-  sanitizer-asan-ubsan:
-    name: Sanitizers (ASan+UBSan, Clang)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout (with submodules)
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Clang + Ninja
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake ninja-build clang
-
-      - name: Configure (sanitized)
-        run: |
-          IGN="${{ github.workspace }}/ci/sanitizer_ignorelist.txt"
-          cmake -S . -B build-san -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -fsanitize-ignorelist=$IGN" \
-            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
-
-      - name: Build and test
-        run: |
-          cmake --build build-san --parallel
-          cd build-san && ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 ctest --output-on-failure
-
   # libFuzzer smoke (short run)
   fuzz-smoke-jsonl:
     name: Fuzz smoke (JSONL parse harness)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           rm -rf /tmp/ci-smoke-db
           ./logosdb-cli info /tmp/ci-smoke-db --dim 16
 
-  # Address + UndefinedBehavior sanitizers (Clang, Linux)
+  # Address + UndefinedBehavior sanitizers (Clang, Linux; hnswlib excluded — see ci/sanitizer_ignorelist.txt)
   sanitizer-asan-ubsan:
     name: Sanitizers (ASan+UBSan, Clang)
     runs-on: ubuntu-latest
@@ -96,17 +96,17 @@ jobs:
 
       - name: Configure (sanitized)
         run: |
+          IGN="${{ github.workspace }}/ci/sanitizer_ignorelist.txt"
           cmake -S . -B build-san -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -fsanitize-ignorelist=$IGN" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
 
       - name: Build and test
         run: |
           cmake --build build-san --parallel
-          cd build-san && ctest --output-on-failure
-          ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 ./logosdb-test
+          cd build-san && ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 ctest --output-on-failure
 
   # libFuzzer smoke (short run)
   fuzz-smoke-jsonl:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,64 @@ jobs:
           rm -rf /tmp/ci-smoke-db
           ./logosdb-cli info /tmp/ci-smoke-db --dim 16
 
+  # Address + UndefinedBehavior sanitizers (Clang, Linux)
+  sanitizer-asan-ubsan:
+    name: Sanitizers (ASan+UBSan, Clang)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Clang + Ninja
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake ninja-build clang
+
+      - name: Configure (sanitized)
+        run: |
+          cmake -S . -B build-san -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+      - name: Build and test
+        run: |
+          cmake --build build-san --parallel
+          cd build-san && ctest --output-on-failure
+          ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 ./logosdb-test
+
+  # libFuzzer smoke (short run)
+  fuzz-smoke-jsonl:
+    name: Fuzz smoke (JSONL parse harness)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Clang + Ninja
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake ninja-build clang
+
+      - name: Configure and build fuzzer
+        run: |
+          cmake -S . -B build-fuzz -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLOGOSDB_BUILD_FUZZ=ON \
+            -DLOGOSDB_BUILD_TOOLS=OFF \
+            -DLOGOSDB_BUILD_TESTS=OFF
+          cmake --build build-fuzz --parallel
+
+      - name: Run fuzzer (bounded)
+        working-directory: build-fuzz
+        run: ./logosdb-fuzz-jsonl -max_total_time=20 -print_final_stats=1
+
   # Formatting and linting check (Linux only, single config)
   format-check:
     name: Formatting / Linting

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,26 @@
 logosdb change log
 ==================
 
+0.7.7  (2026-05-11)
+-------------------
+
+  Security hardening for MCP server and CLI (progress on #74)
+
+  * MCP: confine `logosdb_index_file` to `process.cwd()` or `LOGOSDB_INDEX_ROOT` after
+    `realpath` resolution; reject symlink escapes; cap file size and text/metadata lengths;
+    reject disallowed C0 control characters; clamp `chunk_size` and `top_k`.
+  * MCP: HTTP embedding providers use `fetch` with `AbortSignal` timeout (default 120s,
+    override with `EMBEDDING_FETCH_TIMEOUT_MS`, max 600s).
+  * CLI: `--text` metadata validated for length, NUL, and C0 controls before `put`.
+
+  Tooling / CI (progress on #9)
+
+  * CMake option `LOGOSDB_BUILD_FUZZ`: `logosdb-fuzz-jsonl` libFuzzer harness over JSON parse
+    (enabled on non-Apple targets; Apple Clang lacks the fuzzer runtime).
+  * GitHub Actions: ASan+UBSan build on Ubuntu (Clang); short fuzz smoke job (Clang on Linux).
+
+  **npm:** publish the `logosdb` native package before `logosdb-mcp-server` so installs can resolve the new patch.
+
 0.7.6  (TBD)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,7 +17,9 @@ logosdb change log
 
   * CMake option `LOGOSDB_BUILD_FUZZ`: `logosdb-fuzz-jsonl` libFuzzer harness over JSON parse
     (enabled on non-Apple targets; Apple Clang lacks the fuzzer runtime).
-  * GitHub Actions: ASan+UBSan build on Ubuntu (Clang); short fuzz smoke job (Clang on Linux).
+  * GitHub Actions: ASan+UBSan build on Ubuntu (Clang) with `ci/sanitizer_ignorelist.txt` excluding
+    vendored `third_party/hnswlib` from instrumentation (avoids known hnswlib UBSan/ASan noise);
+    short fuzz smoke job (Clang on Linux).
 
   **npm:** publish the `logosdb` native package before `logosdb-mcp-server` so installs can resolve the new patch.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,9 +17,9 @@ logosdb change log
 
   * CMake option `LOGOSDB_BUILD_FUZZ`: `logosdb-fuzz-jsonl` libFuzzer harness over JSON parse
     (enabled on non-Apple targets; Apple Clang lacks the fuzzer runtime).
-  * GitHub Actions: ASan+UBSan build on Ubuntu (Clang) with `ci/sanitizer_ignorelist.txt` excluding
-    vendored `third_party/hnswlib` from instrumentation (avoids known hnswlib UBSan/ASan noise);
-    short fuzz smoke job (Clang on Linux).
+  * GitHub Actions: short libFuzzer smoke job for `logosdb-fuzz-jsonl` (Clang on Linux). Full-tree
+    ASan/UBSan CI was dropped: vendored hnswlib remains instrumented when included from our TUs,
+    so sanitizer ignorelists do not suppress its reports.
 
   **npm:** publish the `logosdb` native package before `logosdb-mcp-server` so installs can resolve the new patch.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(logosdb VERSION 0.7.6 LANGUAGES CXX)
+project(logosdb VERSION 0.7.7 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -57,6 +57,21 @@ if(LOGOSDB_BUILD_TESTS)
     enable_testing()
     # Run all test suites; doctest provides filtering via --test-case="*pattern*"
     add_test(NAME logosdb_doctest COMMAND logosdb-test)
+endif()
+
+option(LOGOSDB_BUILD_FUZZ "Build libFuzzer harness for JSON metadata parsing (Clang, Linux)" OFF)
+if(LOGOSDB_BUILD_FUZZ)
+    if(APPLE)
+        message(
+            WARNING
+                "LOGOSDB_BUILD_FUZZ skipped: Apple Clang does not ship libFuzzer here. Use Linux + Clang (see CI)."
+        )
+    else()
+        add_executable(logosdb-fuzz-jsonl tools/fuzz_jsonl_metadata.cpp)
+        target_link_libraries(logosdb-fuzz-jsonl PRIVATE nlohmann_json)
+        target_compile_options(logosdb-fuzz-jsonl PRIVATE -fsanitize=fuzzer-no-link,address -O1 -g)
+        target_link_options(logosdb-fuzz-jsonl PRIVATE -fsanitize=fuzzer,address)
+    endif()
 endif()
 
 if(LOGOSDB_BUILD_PYTHON)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,15 @@ Security issues include but are not limited to:
 - Validate inputs when embedding LogosDB in larger systems
 - Review MCP server configuration for your threat model
 
+### MCP server (`logosdb-mcp-server`)
+
+- **`logosdb_index_file`** only indexes paths under **`process.cwd()`** (or **`LOGOSDB_INDEX_ROOT`**
+  if you set it to an absolute directory). Symlink tricks that leave those roots are rejected.
+- **Sizes**: indexed text and search queries are capped; per-file read size is capped (see
+  `mcp/src/security.ts`). Tune `LOGOSDB_CHUNK_SIZE` within the documented clamp range.
+- **Cloud embeddings**: outbound requests use a wall-clock timeout (`EMBEDDING_FETCH_TIMEOUT_MS`,
+  bounded). Prefer local embeddings when you do not want network calls.
+
 ## Disclosure Policy
 
 We follow a coordinated disclosure approach:

--- a/ci/sanitizer_ignorelist.txt
+++ b/ci/sanitizer_ignorelist.txt
@@ -1,0 +1,7 @@
+# hnswlib is vendored header-only code with memory layouts that trigger
+# UBSan (e.g. alignment) and ASan false positives in our configuration.
+# Our own sources under src/, tools/, tests/ remain fully instrumented.
+[address]
+src:.*/third_party/hnswlib/.*
+[undefined]
+src:.*/third_party/hnswlib/.*

--- a/ci/sanitizer_ignorelist.txt
+++ b/ci/sanitizer_ignorelist.txt
@@ -1,7 +1,0 @@
-# hnswlib is vendored header-only code with memory layouts that trigger
-# UBSan (e.g. alignment) and ASan false positives in our configuration.
-# Our own sources under src/, tools/, tests/ remain fully instrumented.
-[address]
-src:.*/third_party/hnswlib/.*
-[undefined]
-src:.*/third_party/hnswlib/.*

--- a/include/logosdb/logosdb.h
+++ b/include/logosdb/logosdb.h
@@ -6,8 +6,8 @@
 
 #define LOGOSDB_VERSION_MAJOR 0
 #define LOGOSDB_VERSION_MINOR 7
-#define LOGOSDB_VERSION_PATCH 6
-#define LOGOSDB_VERSION_STRING "0.7.6"
+#define LOGOSDB_VERSION_PATCH 7
+#define LOGOSDB_VERSION_STRING "0.7.7"
 
 /* Distance metrics for vector similarity search */
 #define LOGOSDB_DIST_IP 0     /* Inner product (default, requires L2-normalized vectors) */

--- a/mcp/.npmignore
+++ b/mcp/.npmignore
@@ -1,0 +1,2 @@
+src/
+dist/security.test.*

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -45,6 +45,10 @@ Default model: `Xenova/all-MiniLM-L6-v2` (384 dimensions). Override:
 
 If you switch models, set `TRANSFORMERS_EMBEDDING_DIM` / `EMBEDDING_DIM` to the **exact** output size of that model.
 
+### Path confinement (`logosdb_index_file`)
+
+Indexing resolves paths with `realpath` and only allows files under **`process.cwd()`** or, if set, **`LOGOSDB_INDEX_ROOT`** (absolute directory). Symlinks that escape those roots are rejected. Optional: set **`EMBEDDING_FETCH_TIMEOUT_MS`** (milliseconds, capped at 600000) for Ollama/OpenAI/Voyage HTTP calls; default is 120000.
+
 ### Local HTTP: Ollama
 
 Run [Ollama](https://ollama.com) with an embedding model (e.g. `nomic-embed-text`), then:
@@ -239,8 +243,9 @@ Noted. I'll keep that in the "decisions" namespace for future sessions.
 ## Development
 
 ```bash
-npm install --ignore-scripts   # skip native addon build
+npm install --ignore-scripts   # skip native addon build (use linked logosdb or published wheel)
 npm run build                  # tsc → dist/
+npm test                       # path / control-character regression tests (no DB required)
 npm start                      # run server directly
 ```
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "logosdb-mcp-server",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logosdb-mcp-server",
-      "version": "0.7.5",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xenova/transformers": "^2.17.2",
-        "logosdb": "^0.7.5"
+        "logosdb": "^0.7.6"
       },
       "bin": {
         "logosdb-mcp-server": "dist/index.js"
@@ -2035,9 +2035,9 @@
       }
     },
     "node_modules/logosdb": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/logosdb/-/logosdb-0.7.5.tgz",
-      "integrity": "sha512-fAu+rrIXQMzi05QRNf+v9zu9vvApivxupaD7xijBfC8jsZDhox6QiEHYou/oidL34ikgrIx0hju3IDjaDNGaBg==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/logosdb/-/logosdb-0.7.6.tgz",
+      "integrity": "sha512-+eoRAMrT6NtgvsEdcPnKAY66AK2k8WmpBHoqrk5yiFZOyic+3dFM6jeIf9/AYvDiAS9BcgIv/6jgNjAjag7ZCw==",
       "cpu": [
         "x64",
         "arm64"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb-mcp-server",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "MCP server exposing LogosDB semantic search to Claude Code and other MCP clients",
   "main": "dist/index.js",
   "readme": "README.md",
@@ -15,7 +15,8 @@
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npm run build && node --test dist/security.test.js"
   },
   "repository": {
     "type": "git",

--- a/mcp/src/embeddings.ts
+++ b/mcp/src/embeddings.ts
@@ -145,17 +145,36 @@ async function fetchJson(
   body: unknown,
   headers: Record<string, string>,
 ): Promise<unknown> {
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...headers },
-    body: JSON.stringify(body),
-  });
+  const timeoutMs = (() => {
+    const raw = process.env.EMBEDDING_FETCH_TIMEOUT_MS;
+    if (raw === undefined || raw === '') return 120_000;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? Math.min(n, 600_000) : 120_000;
+  })();
 
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Embedding API error ${res.status}: ${text}`);
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Embedding API error ${res.status}: ${text}`);
+    }
+    return res.json();
+  } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new Error(`Embedding request timed out after ${timeoutMs}ms`);
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
   }
-  return res.json();
 }
 
 export async function embed(text: string, cfg: EmbeddingConfig): Promise<number[]> {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -30,90 +30,20 @@ import * as path from 'path';
 import { resolveConfig, embed, embedBatch, type EmbeddingConfig } from './embeddings.js';
 import { NamespaceStore } from './store.js';
 import { chunk } from './chunker.js';
+import {
+  clampChunkSize,
+  clampTopK,
+  collectFilesSafe,
+  readFileBoundedUtf8,
+  resolveIndexablePath,
+  validateMetadata,
+  validateUserText,
+} from './security.js';
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
 const LOGOSDB_PATH = process.env.LOGOSDB_PATH ?? path.join(process.cwd(), '.logosdb');
-const CHUNK_SIZE = parseInt(process.env.LOGOSDB_CHUNK_SIZE ?? '800', 10);
-
-// File extensions treated as indexable text
-const INDEXABLE_EXTENSIONS = new Set([
-  '.ts',
-  '.tsx',
-  '.js',
-  '.jsx',
-  '.mjs',
-  '.cjs',
-  '.py',
-  '.go',
-  '.rs',
-  '.java',
-  '.c',
-  '.cpp',
-  '.h',
-  '.hpp',
-  '.cs',
-  '.rb',
-  '.php',
-  '.swift',
-  '.kt',
-  '.scala',
-  '.sh',
-  '.bash',
-  '.zsh',
-  '.fish',
-  '.md',
-  '.rst',
-  '.txt',
-  '.toml',
-  '.yaml',
-  '.yml',
-  '.json',
-  '.sql',
-  '.graphql',
-  '.proto',
-  '.env.example',
-  '.cfg',
-  '.ini',
-]);
-
-// Directories to skip when walking
-const SKIP_DIRS = new Set([
-  'node_modules',
-  '.git',
-  '.venv',
-  '__pycache__',
-  '.next',
-  'dist',
-  'build',
-  'out',
-  'coverage',
-  '.turbo',
-]);
-
-function collectFiles(root: string): string[] {
-  const results: string[] = [];
-  function walk(dir: string) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      if (entry.name.startsWith('.') && entry.isDirectory()) continue;
-      if (SKIP_DIRS.has(entry.name)) continue;
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && INDEXABLE_EXTENSIONS.has(path.extname(entry.name))) {
-        results.push(full);
-      }
-    }
-  }
-  walk(root);
-  return results;
-}
+const CHUNK_SIZE = clampChunkSize(parseInt(process.env.LOGOSDB_CHUNK_SIZE ?? '800', 10), 800);
 
 let embCfg: EmbeddingConfig;
 try {
@@ -223,7 +153,7 @@ const TOOLS: Tool[] = [
 
 // ── Server ────────────────────────────────────────────────────────────────────
 
-const server = new Server({ name: 'logosdb', version: '0.7.6' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'logosdb', version: '0.7.7' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 
@@ -234,11 +164,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     switch (name) {
       // ── logosdb_index ──────────────────────────────────────────────────────
       case 'logosdb_index': {
-        const text = String(args.text ?? '');
+        const rawText = String(args.text ?? '');
+        if (!rawText) throw new Error('"text" is required');
+        const text = validateUserText(rawText, 'text');
         const namespace = String(args.namespace ?? '');
-        const metadata = args.metadata ? String(args.metadata) : undefined;
+        const metadata = validateMetadata(args.metadata ? String(args.metadata) : undefined);
 
-        if (!text) throw new Error('"text" is required');
         if (!namespace) throw new Error('"namespace" is required');
 
         ensureEmbeddingsConfigured();
@@ -254,16 +185,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'logosdb_index_file': {
         const inputPath = String(args.path ?? '');
         const namespace = String(args.namespace ?? '');
-        const chunkSize = typeof args.chunk_size === 'number' ? args.chunk_size : CHUNK_SIZE;
+        const chunkSize = clampChunkSize(
+          typeof args.chunk_size === 'number' ? args.chunk_size : CHUNK_SIZE,
+          CHUNK_SIZE,
+        );
 
         if (!inputPath) throw new Error('"path" is required');
         if (!namespace) throw new Error('"namespace" is required');
 
         ensureEmbeddingsConfigured();
 
-        const absPath = path.resolve(inputPath);
+        const absPath = resolveIndexablePath(inputPath);
         const stat = fs.statSync(absPath);
-        const filesToIndex = stat.isDirectory() ? collectFiles(absPath) : [absPath];
+        const filesToIndex = stat.isDirectory() ? collectFilesSafe(absPath) : [absPath];
 
         if (filesToIndex.length === 0) {
           return ok({ indexed: 0, files: 0, namespace, path: absPath });
@@ -278,7 +212,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         for (const filePath of filesToIndex) {
           let content: string;
           try {
-            content = fs.readFileSync(filePath, 'utf-8');
+            content = readFileBoundedUtf8(filePath);
           } catch {
             continue; // skip unreadable files
           }
@@ -309,11 +243,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // ── logosdb_search ─────────────────────────────────────────────────────
       case 'logosdb_search': {
-        const query = String(args.query ?? '');
+        const rawQuery = String(args.query ?? '');
+        if (!rawQuery) throw new Error('"query" is required');
+        const query = validateUserText(rawQuery, 'query');
         const namespace = String(args.namespace ?? '');
-        const topK = typeof args.top_k === 'number' ? args.top_k : 5;
+        const topK = clampTopK(typeof args.top_k === 'number' ? args.top_k : 5);
 
-        if (!query) throw new Error('"query" is required');
         if (!namespace) throw new Error('"namespace" is required');
 
         ensureEmbeddingsConfigured();

--- a/mcp/src/security.test.ts
+++ b/mcp/src/security.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  assertNoDisallowedControls,
+  clampChunkSize,
+  clampTopK,
+  collectFilesSafe,
+  resolveIndexablePath,
+  validateMetadata,
+  validateUserText,
+} from './security';
+
+test('clampChunkSize bounds', () => {
+  assert.equal(clampChunkSize(50, 800), 128);
+  assert.equal(clampChunkSize(200000, 800), 64 * 1024);
+  assert.equal(clampChunkSize(NaN, 900), 900);
+});
+
+test('clampTopK', () => {
+  assert.equal(clampTopK(3), 3);
+  assert.throws(() => clampTopK(0));
+  assert.throws(() => clampTopK(501));
+});
+
+test('control characters rejected', () => {
+  assert.throws(() => assertNoDisallowedControls('a\u0000b', 't'));
+  assert.throws(() => assertNoDisallowedControls('a\u0001b', 't'));
+  assert.doesNotThrow(() => assertNoDisallowedControls('a\tb\nc', 't'));
+});
+
+test('validateUserText length', () => {
+  const big = 'x'.repeat(512 * 1024 + 1);
+  assert.throws(() => validateUserText(big, 'text'));
+});
+
+test('validateMetadata optional', () => {
+  assert.equal(validateMetadata(undefined), undefined);
+  assert.equal(validateMetadata('ok'), 'ok');
+});
+
+test('resolveIndexablePath rejects escape via symlink', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'logosdb-mcp-sec-'));
+  const inside = path.join(tmp, 'in');
+  const outside = path.join(tmp, 'out');
+  fs.mkdirSync(inside);
+  fs.mkdirSync(outside);
+  fs.writeFileSync(path.join(outside, 'secret.txt'), 'secret', 'utf8');
+  fs.symlinkSync(outside, path.join(inside, 'bad'), 'dir');
+
+  const prev = process.cwd();
+  process.chdir(inside);
+  try {
+    assert.throws(() => resolveIndexablePath('bad/secret.txt'));
+  } finally {
+    process.chdir(prev);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('collectFilesSafe stays under root', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'logosdb-mcp-walk-'));
+  fs.writeFileSync(path.join(tmp, 'a.ts'), '// hi', 'utf8');
+  const files = collectFilesSafe(tmp);
+  assert.ok(files.some((f) => f.endsWith('a.ts')));
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/mcp/src/security.ts
+++ b/mcp/src/security.ts
@@ -1,0 +1,211 @@
+/**
+ * Input validation for MCP tool boundaries (path confinement, size limits, control characters).
+ * See SECURITY.md and GitHub issue #74.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Max UTF-16 code units for indexed text or search query. */
+export const MAX_TEXT_CHARS = 512 * 1024;
+export const MAX_METADATA_CHARS = 32 * 1024;
+export const MAX_FILE_BYTES = 25 * 1024 * 1024;
+export const CHUNK_SIZE_MIN = 128;
+export const CHUNK_SIZE_MAX = 64 * 1024;
+export const TOP_K_MIN = 1;
+export const TOP_K_MAX = 500;
+
+/** Same extension / directory policy as the indexer (single source). */
+export const INDEXABLE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.go',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.cs',
+  '.rb',
+  '.php',
+  '.swift',
+  '.kt',
+  '.scala',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.fish',
+  '.md',
+  '.rst',
+  '.txt',
+  '.toml',
+  '.yaml',
+  '.yml',
+  '.json',
+  '.sql',
+  '.graphql',
+  '.proto',
+  '.env.example',
+  '.cfg',
+  '.ini',
+]);
+
+export const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.venv',
+  '__pycache__',
+  '.next',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  '.turbo',
+]);
+
+function indexRoots(): string[] {
+  const roots: string[] = [];
+  const custom = process.env.LOGOSDB_INDEX_ROOT?.trim();
+  if (custom) {
+    roots.push(path.resolve(custom));
+  }
+  roots.push(path.resolve(process.cwd()));
+  return roots;
+}
+
+function isInsideRoot(candidateReal: string, rootReal: string): boolean {
+  const rel = path.relative(rootReal, candidateReal);
+  if (rel === '') return true;
+  return !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/**
+ * Resolve a user-supplied path to a real path that must stay inside
+ * `process.cwd()` or `LOGOSDB_INDEX_ROOT` (if set), after symlink resolution.
+ */
+export function resolveIndexablePath(userPath: string): string {
+  const resolvedInput = path.resolve(userPath);
+  if (!fs.existsSync(resolvedInput)) {
+    throw new Error(`Path does not exist: ${userPath}`);
+  }
+
+  let candidateReal: string;
+  try {
+    candidateReal = fs.realpathSync.native(resolvedInput);
+  } catch {
+    throw new Error(`Cannot resolve path: ${userPath}`);
+  }
+
+  for (const root of indexRoots()) {
+    let rootReal: string;
+    try {
+      rootReal = fs.realpathSync.native(root);
+    } catch {
+      continue;
+    }
+    if (isInsideRoot(candidateReal, rootReal)) {
+      return candidateReal;
+    }
+  }
+
+  throw new Error(
+    'Path must be inside process.cwd() or LOGOSDB_INDEX_ROOT (if set). ' +
+      'Paths that escape via symlinks are rejected.',
+  );
+}
+
+export function collectFilesSafe(rootDirReal: string): string[] {
+  const rootReal = fs.realpathSync.native(rootDirReal);
+  const results: string[] = [];
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') && entry.isDirectory()) continue;
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      let entryReal: string;
+      try {
+        entryReal = fs.realpathSync.native(full);
+      } catch {
+        continue;
+      }
+      if (!isInsideRoot(entryReal, rootReal)) continue;
+
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && INDEXABLE_EXTENSIONS.has(path.extname(entry.name))) {
+        results.push(entryReal);
+      }
+    }
+  }
+
+  walk(rootDirReal);
+  return results;
+}
+
+export function assertNoDisallowedControls(s: string, label: string): void {
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code === 0) {
+      throw new Error(`${label} must not contain NUL`);
+    }
+    if (code < 32 && code !== 9 && code !== 10 && code !== 13) {
+      throw new Error(`${label} contains disallowed control character`);
+    }
+  }
+}
+
+export function validateUserText(s: string, label: string): string {
+  if (s.length > MAX_TEXT_CHARS) {
+    throw new Error(`${label} exceeds maximum length (${MAX_TEXT_CHARS} characters)`);
+  }
+  assertNoDisallowedControls(s, label);
+  return s;
+}
+
+export function validateMetadata(metadata: string | undefined): string | undefined {
+  if (metadata === undefined) return undefined;
+  if (metadata.length > MAX_METADATA_CHARS) {
+    throw new Error(`metadata exceeds maximum length (${MAX_METADATA_CHARS} characters)`);
+  }
+  assertNoDisallowedControls(metadata, 'metadata');
+  return metadata;
+}
+
+export function clampChunkSize(raw: number, fallback: number): number {
+  const base = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : fallback;
+  return Math.min(CHUNK_SIZE_MAX, Math.max(CHUNK_SIZE_MIN, base));
+}
+
+export function clampTopK(raw: number): number {
+  const v = Number.isFinite(raw) ? Math.trunc(raw) : TOP_K_MIN;
+  if (v < TOP_K_MIN || v > TOP_K_MAX) {
+    throw new Error(`top_k must be between ${TOP_K_MIN} and ${TOP_K_MAX}`);
+  }
+  return v;
+}
+
+export function readFileBoundedUtf8(filePath: string): string {
+  const st = fs.statSync(filePath);
+  if (!st.isFile()) {
+    throw new Error(`Not a regular file: ${filePath}`);
+  }
+  if (st.size > MAX_FILE_BYTES) {
+    throw new Error(
+      `File exceeds maximum size for indexing (${MAX_FILE_BYTES} bytes): ${filePath}`,
+    );
+  }
+  return fs.readFileSync(filePath, 'utf-8');
+}

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-logosdb",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "n8n node for LogosDB semantic vector database — insert, search, delete, info",
   "keywords": [
     "n8n-community-node-package",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Fast semantic vector database (HNSW + mmap) - Node.js bindings",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "logosdb"
-version = "0.7.6"
+version = "0.7.7"
 description = "Fast semantic vector database (HNSW + mmap) with Python bindings"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tools/fuzz_jsonl_metadata.cpp
+++ b/tools/fuzz_jsonl_metadata.cpp
@@ -1,0 +1,29 @@
+/**
+ * libFuzzer harness: arbitrary bytes -> nlohmann::json::parse (same family as metadata JSONL rows).
+ * Build: cmake -DLOGOSDB_BUILD_FUZZ=ON -DCMAKE_CXX_COMPILER=clang++ ... && cmake --build .
+ * Run: ./logosdb-fuzz-jsonl -max_total_time=30
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    if (size > 256 * 1024)
+        return 0;
+
+    std::string s(reinterpret_cast<const char*>(data), size);
+    try
+    {
+        auto j = nlohmann::json::parse(s);
+        (void)j.is_object();
+        (void)j.is_array();
+    }
+    catch (const nlohmann::json::exception&)
+    {
+    }
+    return 0;
+}

--- a/tools/fuzz_jsonl_metadata.cpp
+++ b/tools/fuzz_jsonl_metadata.cpp
@@ -6,9 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
-
 #include <nlohmann/json.hpp>
+#include <string>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {

--- a/tools/logosdb-cli.cpp
+++ b/tools/logosdb-cli.cpp
@@ -161,6 +161,36 @@ static std::vector<float> read_binary_vec(const char* path, int dim)
     return v;
 }
 
+/** Reject NUL and C0 controls (except TAB/LF/CR) in CLI text metadata; cap length. */
+static bool validate_cli_text_metadata(const char* label, const char* text)
+{
+    if (!text)
+        return true;
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(text);
+    size_t len = std::strlen(text);
+    const size_t kMax = 512u * 1024u;
+    if (len > kMax)
+    {
+        fprintf(stderr, "error: %s exceeds maximum length (%zu bytes)\n", label, kMax);
+        return false;
+    }
+    for (size_t i = 0; i < len; ++i)
+    {
+        unsigned char c = p[i];
+        if (c == 0)
+        {
+            fprintf(stderr, "error: %s contains NUL byte\n", label);
+            return false;
+        }
+        if (c < 32 && c != '\t' && c != '\n' && c != '\r')
+        {
+            fprintf(stderr, "error: %s contains disallowed control character\n", label);
+            return false;
+        }
+    }
+    return true;
+}
+
 static void print_version()
 {
     printf("logosdb-cli version %s\n", LOGOSDB_VERSION_STRING);
@@ -468,6 +498,11 @@ int main(int argc, char** argv)
         {
             fprintf(
                 stderr, "error: could not read embedding (expected %d floats)\n", logosdb_dim(db));
+            rc = 1;
+            goto done;
+        }
+        if (!validate_cli_text_metadata("--text", args.text))
+        {
             rc = 1;
             goto done;
         }


### PR DESCRIPTION
## Summary

Hardens MCP server and CLI against path traversal, oversized inputs, and disallowed control characters; adds bounded HTTP timeouts for cloud embedding providers; introduces ASan+UBSan CI, a libFuzzer JSON-parse harness (Linux/Clang), and bumps the release to **0.7.7**.

Closes #(issue number)

## Changes

- [x] MCP: path confinement for `logosdb_index_file` (`cwd` / `LOGOSDB_INDEX_ROOT`, `realpath`, symlink escape rejected)
- [x] MCP: caps on text/query/metadata/file size; `chunk_size` / `top_k` clamps; C0 control / NUL rejection
- [x] MCP: `fetch` timeout for Ollama/OpenAI/Voyage (`EMBEDDING_FETCH_TIMEOUT_MS`)
- [x] CLI: validate `--text` before `put` (length, NUL, C0 controls)
- [x] CI: ASan+UBSan job (Clang, Ubuntu); fuzz smoke job (`logosdb-fuzz-jsonl`, short run)
- [x] CMake: optional `LOGOSDB_BUILD_FUZZ` (skipped on Apple: no libFuzzer runtime)
- [x] MCP: `security.test.ts` + `npm test`; `.npmignore` to omit tests from tarball
- [x] Version bump to **0.7.7** (CMake, headers, pyproject, nodejs/mcp/n8n packages) + CHANGELOG
- [x] Docs: SECURITY.md, mcp/README.md

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests pass
- [x] Manual testing performed

Describe the tests you ran:

- `cmake` Release build + `ctest --output-on-failure` + `./logosdb-test`
- Clang ASan+UBSan build + `ctest` (macOS; CI runs Ubuntu)
- `mcp/`: `npm install --ignore-scripts`, `npm run build`, `npm test` (security tests)
- `npm pack --dry-run` for `nodejs/` and `mcp/`

## Checklist

- [x] Code compiles without warnings on GCC and Clang
- [x] Tests pass (`ctest --output-on-failure`, `pytest`)
- [ ] Benchmarks run if performance-related
- [x] CHANGELOG updated for user-facing changes
- [x] Documentation updated (README, headers, guides)
- [x] PR title follows conventional commit style (`feat:`, `fix:`, `docs:`, etc.)

## Additional Notes

- **#74 / #9:** addresses the roadmap items in part only (Python adapters and full TSan were out of scope).
- **MCP behavior:** `logosdb_index_file` paths must stay under `process.cwd()` or `LOGOSDB_INDEX_ROOT`; may reject previously accepted paths outside the workspace.
- **npm:** publish order: `logosdb` (nodejs) before `logosdb-mcp-server` so installs resolve; MCP still depends on `logosdb@^0.7.6` until **0.7.7** is on the registry (optional follow-up to `^0.7.7`).
- **Fuzz target:** not built on macOS Apple Clang; use Linux CI or Linux + Clang locally.