### PR TITLE
feat(mcp): respect repo .gitignore (root + nested + info/exclude + global) when walking directories for logosdb_index_file (#101)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,25 @@
 logosdb change log
 ==================
 
-0.9.0  (unreleased)
+0.9.1  (unreleased) — `logosdb-mcp-server` only
+-----------------------------------------------
+
+  * **#101 — `.gitignore`-aware indexing in `logosdb_index_file`:** when the
+    indexed path lives inside a Git working tree, the directory walker now
+    honours `.gitignore` rules (root + nested per-directory + `.git/info/exclude`
+    + the global excludes file at `$XDG_CONFIG_HOME/git/ignore` or
+    `~/.config/git/ignore`) in addition to the legacy `SKIP_DIRS` / hidden /
+    extension filters. Pattern semantics (leading `/`, trailing `/`, `**`,
+    negations `!pattern`) are delegated to the `ignore` npm package (Git-spec
+    compatible). The new behaviour is **on by default** when a `.git/` dir is
+    found and is a no-op otherwise (no breaking change for non-Git users). Two
+    opt-outs: `LOGOSDB_RESPECT_GITIGNORE=0` (env) and `respect_gitignore: false`
+    (tool argument). New module `mcp/src/gitignore-walker.ts`; new test file
+    `mcp/src/gitignore-walker.test.ts` (13 cases covering nested rules,
+    negation, `info/exclude`, env overrides, and the no-`.git` fallback).
+    `mcp/package.json` adds `ignore@^7` and re-pins `logosdb` to `^0.9.0`.
+
+0.9.0  (2026-05-13)
 -------------------
 
   * **#80 — Batch ingest v2 (WAL-aware, chunked):** `logosdb_put_batch` now writes

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Voyage AI (`voyage-3`, dim=1024) is Anthropic's recommended cloud embedding mode
 | Tool | Description |
 |---|---|
 | `logosdb_index` | Embed and store a text snippet in a namespace |
-| `logosdb_index_file` | Chunk, embed, and store a file or tree; optional **`incremental: true`** (skip unchanged, replace changed, prune deleted under a directory) |
+| `logosdb_index_file` | Chunk, embed, and store a file or tree; optional **`incremental: true`** (skip unchanged, replace changed, prune deleted under a directory). When the path lives inside a Git working tree the walker honours `.gitignore` (root + nested + `.git/info/exclude` + global excludes) by default; disable with `respect_gitignore: false` or `LOGOSDB_RESPECT_GITIGNORE=0`. |
 | `logosdb_search` | Semantic search; optional `ts_from` / `ts_to` (ISO 8601) for timestamp-window filter |
 | `logosdb_list` | List all namespaces |
 | `logosdb_info` | Stats for a namespace (count, dimension, path) |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -123,6 +123,26 @@ If you switch models, set `TRANSFORMERS_EMBEDDING_DIM` / `EMBEDDING_DIM` to the 
 
 Indexing resolves paths with `realpath` and only allows files under **`process.cwd()`** or, if set, **`LOGOSDB_INDEX_ROOT`** (absolute directory). Symlinks that escape those roots are rejected. Optional: set **`EMBEDDING_FETCH_TIMEOUT_MS`** (milliseconds, capped at 600000) for Ollama/OpenAI/Voyage HTTP calls; default is 120000.
 
+### `.gitignore`-aware walking (0.9.1)
+
+When `logosdb_index_file` walks a directory that lives inside a Git working tree, it honours `.gitignore` rules **in addition to** the legacy `SKIP_DIRS` / hidden / extension filters. Sources, in Git order:
+
+- the working tree's root **`.gitignore`**,
+- every **nested `.gitignore`** discovered during the walk (per-directory scope),
+- **`.git/info/exclude`**,
+- the **global excludes file** at `$XDG_CONFIG_HOME/git/ignore` (or `~/.config/git/ignore`). Reading `core.excludesFile` from `~/.gitconfig` is **not** parsed; symlink that file into `~/.config/git/ignore` if you need it.
+
+Pattern semantics (leading `/`, trailing `/`, `**`, `!pattern` negations) match Git via the [`ignore`](https://www.npmjs.com/package/ignore) npm package.
+
+**Default:** on when a `.git/` dir is found by walking up from the indexed path (and staying inside `process.cwd()` / `LOGOSDB_INDEX_ROOT`). **No-op** when no Git working tree is detected — non-Git projects see no change.
+
+**Disable** in either of:
+
+- per call: `logosdb_index_file({ path, namespace, respect_gitignore: false })`
+- globally: `LOGOSDB_RESPECT_GITIGNORE=0` (`false`, `no`, `off` all accepted)
+
+The tool response echoes `respect_gitignore: <bool>` so the agent can confirm what was applied.
+
 ### Local HTTP: Ollama
 
 Run [Ollama](https://ollama.com) with an embedding model (e.g. `nomic-embed-text`), then:
@@ -300,6 +320,7 @@ Noted. I'll keep that in the "decisions" namespace for future sessions.
 | `OPENAI_API_KEY` | — | Required when `EMBEDDING_PROVIDER=openai` |
 | `VOYAGE_API_KEY` | — | Required when `EMBEDDING_PROVIDER=voyage` |
 | `LOGOSDB_CHUNK_SIZE` | `800` | Target characters per chunk when indexing files |
+| `LOGOSDB_RESPECT_GITIGNORE` | `1` (auto-on inside a Git working tree) | `0` / `false` / `no` / `off` disables `.gitignore`-aware filtering globally (0.9.1+) |
 
 **Important:** Use one embedding backend consistently for a given namespace on disk. Mixing dimensions or models on the same `LOGOSDB_PATH` namespace will produce invalid search results.
 
@@ -308,7 +329,7 @@ Noted. I'll keep that in the "decisions" namespace for future sessions.
 | Tool | Inputs | Description |
 |---|---|---|
 | `logosdb_index` | `text`, `namespace`, `metadata?` | Embed and store a text snippet |
-| `logosdb_index_file` | `path`, `namespace`, `chunk_size?`, `incremental?` | Chunk, embed, and store a file or tree; **`incremental: true`** skips unchanged files, replaces chunks for changed files, and prunes removed files under a directory (state in `LOGOSDB_PATH/_logosdb_mcp_manifests/`) |
+| `logosdb_index_file` | `path`, `namespace`, `chunk_size?`, `incremental?`, `respect_gitignore?` | Chunk, embed, and store a file or tree; **`incremental: true`** skips unchanged files, replaces chunks for changed files, and prunes removed files under a directory (state in `LOGOSDB_PATH/_logosdb_mcp_manifests/`). When the path lives inside a Git working tree, `.gitignore` rules are applied by default (override per call with `respect_gitignore: false` or globally with `LOGOSDB_RESPECT_GITIGNORE=0`; see [`.gitignore`-aware walking](#gitignore-aware-walking-091)) |
 | `logosdb_search` | `query`, `namespace`, `top_k?`, `ts_from?`, `ts_to?`, `candidate_k?` | Semantic search; optional inclusive ISO 8601 time window (maps to `search_ts_range`) |
 | `logosdb_list` | — | List all namespaces |
 | `logosdb_info` | `namespace` | Stats: count, live count, dimension |

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb-mcp-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "MCP server exposing LogosDB semantic search to Claude Code and other MCP clients",
   "main": "dist/index.js",
   "readme": "README.md",
@@ -18,7 +18,7 @@
     "format:check": "prettier --check src/",
     "prepublishOnly": "npm run build",
     "smoke": "node scripts/mcp-stdio-smoke.mjs",
-    "test": "npm run build && node --test dist/security.test.js dist/file-index-manifest.test.js && npm run smoke"
+    "test": "npm run build && node --test dist/security.test.js dist/file-index-manifest.test.js dist/gitignore-walker.test.js && npm run smoke"
   },
   "repository": {
     "type": "git",
@@ -43,7 +43,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xenova/transformers": "^2.17.2",
-    "logosdb": "^0.8.0"
+    "ignore": "^7.0.5",
+    "logosdb": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/mcp/src/file-index-manifest.test.ts
+++ b/mcp/src/file-index-manifest.test.ts
@@ -59,6 +59,9 @@ describe('file-index-manifest', () => {
     assert.ok(!manifest.files['/proj/b.ts']);
     assert.ok(manifest.files['/proj/a.ts']);
     assert.ok(manifest.files['/other/x.ts']);
-    assert.deepEqual(deleted.sort((a, b) => a - b), [20, 21]);
+    assert.deepEqual(
+      deleted.sort((a, b) => a - b),
+      [20, 21],
+    );
   });
 });

--- a/mcp/src/file-index-manifest.ts
+++ b/mcp/src/file-index-manifest.ts
@@ -46,7 +46,8 @@ function sanitizeEntry(raw: unknown): FileIndexEntry | null {
       if (Number.isFinite(n)) ids.push(n);
     }
   }
-  if (!Number.isFinite(mtimeMs) || !Number.isFinite(size) || !Number.isFinite(chunkSize)) return null;
+  if (!Number.isFinite(mtimeMs) || !Number.isFinite(size) || !Number.isFinite(chunkSize))
+    return null;
   return { mtimeMs, size, chunkSize, ids };
 }
 
@@ -54,7 +55,8 @@ export function loadManifest(filePath: string): FileIndexManifest {
   try {
     const raw = fs.readFileSync(filePath, 'utf-8');
     const j = JSON.parse(raw) as { version?: unknown; files?: unknown };
-    if (j?.version !== MANIFEST_VERSION || !j.files || typeof j.files !== 'object') return emptyManifest();
+    if (j?.version !== MANIFEST_VERSION || !j.files || typeof j.files !== 'object')
+      return emptyManifest();
     const files: Record<string, FileIndexEntry> = {};
     for (const [k, v] of Object.entries(j.files as Record<string, unknown>)) {
       const ent = sanitizeEntry(v);

--- a/mcp/src/gitignore-walker.test.ts
+++ b/mcp/src/gitignore-walker.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for `.gitignore`-aware directory walking (issue #101).
+ * Each case builds a synthetic tree under a fresh tmpdir, optionally with a
+ * `.git/` marker so the walker treats it as a working tree.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { collectFilesSafe } from './security';
+import {
+  buildGitignoreContext,
+  findGitRoot,
+  isIgnoredByStack,
+  maybePushLocalGitignore,
+  respectGitignoreDefault,
+} from './gitignore-walker';
+
+function mktmp(prefix = 'logosdb-gitignore-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function write(p: string, body: string): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, body, 'utf8');
+}
+
+function markGit(root: string): void {
+  fs.mkdirSync(path.join(root, '.git'), { recursive: true });
+}
+
+function cdGuard<T>(dir: string, fn: () => T): T {
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    return fn();
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+function basenames(files: string[]): Set<string> {
+  return new Set(files.map((f) => path.basename(f)));
+}
+
+// ── findGitRoot ──────────────────────────────────────────────────────────────
+
+test('findGitRoot returns enclosing .git dir', () => {
+  const tmp = mktmp();
+  try {
+    markGit(tmp);
+    write(path.join(tmp, 'src', 'a.ts'), '// hi');
+    const got = findGitRoot(path.join(tmp, 'src'));
+    assert.equal(got !== null && fs.realpathSync.native(got), fs.realpathSync.native(tmp));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('findGitRoot returns null when no .git is found', () => {
+  const tmp = mktmp();
+  try {
+    write(path.join(tmp, 'a.ts'), '// hi');
+    // Bound the search so it does not climb above tmp into a host repo.
+    assert.equal(findGitRoot(tmp, [tmp]), null);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('findGitRoot stops at a configured boundary', () => {
+  const tmp = mktmp();
+  try {
+    markGit(tmp); // .git lives at tmp
+    const sub = path.join(tmp, 'sub');
+    fs.mkdirSync(sub, { recursive: true });
+    // Boundary = sub  -> walker must not see tmp/.git
+    assert.equal(findGitRoot(sub, [sub]), null);
+    // Without boundary, it finds tmp.
+    const got = findGitRoot(sub);
+    assert.equal(got !== null && fs.realpathSync.native(got), fs.realpathSync.native(tmp));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── Stack composition primitives ─────────────────────────────────────────────
+
+test('isIgnoredByStack honours pattern semantics from a single .gitignore', () => {
+  const tmp = mktmp();
+  try {
+    write(path.join(tmp, '.gitignore'), 'build/\n*.log\n!keep.log\n');
+    const stack = maybePushLocalGitignore([], tmp);
+    assert.equal(stack.length, 1);
+    assert.equal(isIgnoredByStack(stack, path.join(tmp, 'build'), true), true);
+    assert.equal(isIgnoredByStack(stack, path.join(tmp, 'app.log'), false), true);
+    assert.equal(isIgnoredByStack(stack, path.join(tmp, 'keep.log'), false), false);
+    assert.equal(isIgnoredByStack(stack, path.join(tmp, 'src', 'a.ts'), false), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('isIgnoredByStack composes nested .gitignore frames', () => {
+  const tmp = mktmp();
+  try {
+    write(path.join(tmp, '.gitignore'), '*.tmp\n');
+    write(path.join(tmp, 'sub', '.gitignore'), 'secret.txt\n');
+    const root = maybePushLocalGitignore([], tmp);
+    const nested = maybePushLocalGitignore(root, path.join(tmp, 'sub'));
+
+    assert.equal(isIgnoredByStack(nested, path.join(tmp, 'sub', 'secret.txt'), false), true);
+    assert.equal(isIgnoredByStack(nested, path.join(tmp, 'sub', 'foo.tmp'), false), true);
+    assert.equal(isIgnoredByStack(nested, path.join(tmp, 'sub', 'foo.ts'), false), false);
+    // Parent frame must not see the nested rule.
+    assert.equal(isIgnoredByStack(root, path.join(tmp, 'sub', 'secret.txt'), false), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── End-to-end via collectFilesSafe ──────────────────────────────────────────
+
+test('collectFilesSafe skips files matched by repo .gitignore', () => {
+  const tmp = fs.realpathSync.native(mktmp());
+  try {
+    markGit(tmp);
+    write(path.join(tmp, '.gitignore'), 'generated/\n*.log\n');
+    write(path.join(tmp, 'src', 'a.ts'), '// hi');
+    write(path.join(tmp, 'src', 'b.ts'), '// hi');
+    write(path.join(tmp, 'generated', 'big.ts'), '// noise');
+    write(path.join(tmp, 'app.log'), 'noise');
+    write(path.join(tmp, 'README.md'), 'ok');
+
+    cdGuard(tmp, () => {
+      const got = basenames(collectFilesSafe(tmp, { respectGitignore: true }));
+      assert.ok(got.has('a.ts'));
+      assert.ok(got.has('b.ts'));
+      assert.ok(got.has('README.md'));
+      assert.ok(!got.has('big.ts'), 'generated/big.ts must be ignored');
+      assert.ok(!got.has('app.log'), '*.log must be ignored');
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('collectFilesSafe honours nested .gitignore', () => {
+  const tmp = fs.realpathSync.native(mktmp());
+  try {
+    markGit(tmp);
+    write(path.join(tmp, '.gitignore'), '*.tmp\n');
+    write(path.join(tmp, 'pkg', '.gitignore'), 'private/\n');
+    write(path.join(tmp, 'pkg', 'a.ts'), '// keep');
+    write(path.join(tmp, 'pkg', 'private', 'secret.ts'), '// hidden');
+    write(path.join(tmp, 'pkg', 'note.tmp'), 'noise');
+
+    cdGuard(tmp, () => {
+      const got = basenames(collectFilesSafe(tmp, { respectGitignore: true }));
+      assert.ok(got.has('a.ts'));
+      assert.ok(!got.has('secret.ts'), 'nested private/ rule must apply');
+      assert.ok(!got.has('note.tmp'), 'root *.tmp must apply to nested dir');
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('collectFilesSafe honours .git/info/exclude', () => {
+  const tmp = fs.realpathSync.native(mktmp());
+  try {
+    markGit(tmp);
+    write(path.join(tmp, '.git', 'info', 'exclude'), 'scratch.ts\n');
+    write(path.join(tmp, 'keep.ts'), '// keep');
+    write(path.join(tmp, 'scratch.ts'), '// drop');
+
+    cdGuard(tmp, () => {
+      const got = basenames(collectFilesSafe(tmp, { respectGitignore: true }));
+      assert.ok(got.has('keep.ts'));
+      assert.ok(!got.has('scratch.ts'), '.git/info/exclude must be honoured');
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('collectFilesSafe handles negation patterns (!keep)', () => {
+  const tmp = fs.realpathSync.native(mktmp());
+  try {
+    markGit(tmp);
+    write(path.join(tmp, '.gitignore'), '*.log\n!important.log\n');
+    write(path.join(tmp, 'a.log'), 'drop'); // .log is not indexable, but
+    write(path.join(tmp, 'a.ts'), '// keep');
+    // Build a file that *is* indexable and that demonstrates negation effect:
+    // *.md is allow, but if we ignore *.md and re-include keep.md, we should
+    // see keep.md back.
+    write(path.join(tmp, '.gitignore'), '*.md\n!keep.md\n');
+    write(path.join(tmp, 'drop.md'), '# drop');
+    write(path.join(tmp, 'keep.md'), '# keep');
+
+    cdGuard(tmp, () => {
+      const got = basenames(collectFilesSafe(tmp, { respectGitignore: true }));
+      assert.ok(got.has('a.ts'));
+      assert.ok(got.has('keep.md'), 'negation should re-include keep.md');
+      assert.ok(!got.has('drop.md'), '*.md should drop drop.md');
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('collectFilesSafe with respectGitignore=true but no .git falls back', () => {
+  const tmp = fs.realpathSync.native(mktmp());
+  try {
+    // No .git marker. .gitignore should be IGNORED (legacy behaviour preserved).
+    write(path.join(tmp, '.gitignore'), '*.ts\n');
+    write(path.join(tmp, 'a.ts'), '// kept under legacy filter');
+    write(path.join(tmp, 'b.md'), 'kept');
+
+    cdGuard(tmp, () => {
+      const got = basenames(collectFilesSafe(tmp, { respectGitignore: true }));
+      // Without a .git, the .gitignore is moot; .ts is indexable.
+      assert.ok(got.has('a.ts'));
+      assert.ok(got.has('b.md'));
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('collectFilesSafe legacy default (no opts) ignores .gitignore', () => {
+  const tmp = fs.realpathSync.native(mktmp());
+  try {
+    markGit(tmp);
+    write(path.join(tmp, '.gitignore'), '*.ts\n');
+    write(path.join(tmp, 'a.ts'), '// would be dropped if gitignore were on');
+
+    cdGuard(tmp, () => {
+      // No opts -> legacy filter only. a.ts must be present.
+      const got = basenames(collectFilesSafe(tmp));
+      assert.ok(got.has('a.ts'), 'opt-in flag is required');
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── env override ─────────────────────────────────────────────────────────────
+
+test('respectGitignoreDefault env override', () => {
+  const prev = process.env.LOGOSDB_RESPECT_GITIGNORE;
+  try {
+    delete process.env.LOGOSDB_RESPECT_GITIGNORE;
+    assert.equal(respectGitignoreDefault(), true);
+
+    process.env.LOGOSDB_RESPECT_GITIGNORE = '';
+    assert.equal(respectGitignoreDefault(), true);
+
+    process.env.LOGOSDB_RESPECT_GITIGNORE = '1';
+    assert.equal(respectGitignoreDefault(), true);
+
+    for (const off of ['0', 'false', 'FALSE', 'no', 'off']) {
+      process.env.LOGOSDB_RESPECT_GITIGNORE = off;
+      assert.equal(respectGitignoreDefault(), false, `expected ${off} -> false`);
+    }
+  } finally {
+    if (prev === undefined) delete process.env.LOGOSDB_RESPECT_GITIGNORE;
+    else process.env.LOGOSDB_RESPECT_GITIGNORE = prev;
+  }
+});
+
+// ── buildGitignoreContext is robust when files are absent ────────────────────
+
+test('buildGitignoreContext with empty git root', () => {
+  const tmp = fs.realpathSync.native(mktmp());
+  try {
+    markGit(tmp);
+    const ctx = buildGitignoreContext(tmp);
+    assert.equal(ctx.gitRoot, tmp);
+    // No .gitignore and no info/exclude means no frames.
+    assert.equal(ctx.rootStack.length, 0);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/mcp/src/gitignore-walker.ts
+++ b/mcp/src/gitignore-walker.ts
@@ -1,0 +1,155 @@
+/**
+ * `.gitignore`-aware directory walking for `logosdb_index_file` (issue #101).
+ *
+ * Composes ignore rules the way Git does:
+ *   - the root `.gitignore` of the enclosing working tree,
+ *   - every nested `.gitignore` discovered during the walk (per-directory scope),
+ *   - `.git/info/exclude`,
+ *   - the global excludes file (`$XDG_CONFIG_HOME/git/ignore`, falling back to
+ *     `~/.config/git/ignore`).
+ *
+ * Pattern semantics are delegated to the `ignore` npm package (Git-compatible:
+ * leading `/`, trailing `/`, `**`, negations with `!`, etc.).
+ *
+ * This module never reaches outside the resolved Git working tree.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import ignoreFactory, { type Ignore } from 'ignore';
+
+export interface IgnoreFrame {
+  /** Absolute directory the patterns are scoped to (i.e. the dir holding the `.gitignore`). */
+  dir: string;
+  ig: Ignore;
+}
+
+export interface GitignoreContext {
+  /** Absolute path to the enclosing Git working tree. */
+  gitRoot: string;
+  /** Stack of always-active frames (git root + global + info/exclude). */
+  rootStack: IgnoreFrame[];
+}
+
+/** Walk parents looking for a `.git` dir/file. Stops at any `stopAt` boundary
+ *  (use these to keep discovery inside `process.cwd()` / `LOGOSDB_INDEX_ROOT`). */
+export function findGitRoot(startDir: string, stopAt: readonly string[] = []): string | null {
+  let cur = path.resolve(startDir);
+  const stops = stopAt.map((s) => path.resolve(s));
+  while (true) {
+    if (fs.existsSync(path.join(cur, '.git'))) {
+      return cur;
+    }
+    if (stops.some((s) => path.relative(s, cur) === '')) {
+      return null; // hit a configured boundary
+    }
+    const parent = path.dirname(cur);
+    if (parent === cur) return null; // filesystem root
+    cur = parent;
+  }
+}
+
+function safeReadText(p: string): string | null {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function globalIgnoreFile(): string | null {
+  // Prefer XDG; fall back to ~/.config/git/ignore. We do not parse ~/.gitconfig
+  // for `core.excludesFile` (would require a child process); a documented
+  // limitation noted in mcp/README.md.
+  const xdg = process.env.XDG_CONFIG_HOME;
+  if (xdg) {
+    const p = path.join(xdg, 'git', 'ignore');
+    if (fs.existsSync(p)) return p;
+  }
+  const home = os.homedir();
+  if (home) {
+    const p = path.join(home, '.config', 'git', 'ignore');
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+/** Build the always-active ignore stack for a given Git root.
+ *  - Global excludes contribute a frame at `gitRoot` (Git treats them as
+ *    repo-wide rules; testing them with a path relative to gitRoot is fine).
+ *  - Repo `.gitignore` and `.git/info/exclude` likewise scope at gitRoot. */
+export function buildGitignoreContext(gitRoot: string): GitignoreContext {
+  const stack: IgnoreFrame[] = [];
+
+  const ig = ignoreFactory();
+  let added = false;
+
+  const globalPath = globalIgnoreFile();
+  if (globalPath) {
+    const txt = safeReadText(globalPath);
+    if (txt) {
+      ig.add(txt);
+      added = true;
+    }
+  }
+
+  const repoGitignore = safeReadText(path.join(gitRoot, '.gitignore'));
+  if (repoGitignore) {
+    ig.add(repoGitignore);
+    added = true;
+  }
+
+  const infoExclude = safeReadText(path.join(gitRoot, '.git', 'info', 'exclude'));
+  if (infoExclude) {
+    ig.add(infoExclude);
+    added = true;
+  }
+
+  if (added) {
+    stack.push({ dir: gitRoot, ig });
+  }
+
+  return { gitRoot, rootStack: stack };
+}
+
+/** Push a `.gitignore` from `dir` (if any) onto the stack. Returns the same
+ *  stack reference when nothing was added, so callers can use identity to
+ *  decide whether to allocate a child copy. */
+export function maybePushLocalGitignore(stack: IgnoreFrame[], dir: string): IgnoreFrame[] {
+  const txt = safeReadText(path.join(dir, '.gitignore'));
+  if (txt === null) return stack;
+  const ig = ignoreFactory();
+  ig.add(txt);
+  return [...stack, { dir, ig }];
+}
+
+/** Test a path (absolute) against every frame in the stack.
+ *  Convention: each frame's `ig` receives the path **relative to that frame**,
+ *  with a trailing `/` when it is a directory (Git semantics for `pattern/`).
+ *  Cross-frame negations are not honoured (mirrors how globby / `ignore`'s
+ *  composed usage already approximates Git for nested files). */
+export function isIgnoredByStack(
+  stack: readonly IgnoreFrame[],
+  absPath: string,
+  isDir: boolean,
+): boolean {
+  for (const frame of stack) {
+    const rel = path.relative(frame.dir, absPath);
+    if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) continue;
+    // ignore@^7 always wants POSIX separators.
+    const norm = rel.split(path.sep).join('/') + (isDir ? '/' : '');
+    if (frame.ig.ignores(norm)) return true;
+  }
+  return false;
+}
+
+/** Should `logosdb_index_file` apply gitignore filtering by default?
+ *  Returns `true` if `LOGOSDB_RESPECT_GITIGNORE` is unset or truthy. */
+export function respectGitignoreDefault(): boolean {
+  const raw = process.env.LOGOSDB_RESPECT_GITIGNORE;
+  if (raw === undefined || raw === '') return true;
+  const v = raw.toLowerCase();
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -39,6 +39,7 @@ import {
   validateMetadata,
   validateUserText,
 } from './security.js';
+import { respectGitignoreDefault } from './gitignore-walker.js';
 import {
   loadManifest,
   MANIFEST_VERSION,
@@ -97,6 +98,7 @@ const TOOLS: Tool[] = [
     description:
       'Read a file OR directory from disk, chunk each file, embed the chunks, and store them in a namespace. ' +
       'When given a directory it walks recursively, skipping hidden paths and node_modules. ' +
+      'When a Git working tree is detected the walker honours `.gitignore` (root + nested + `.git/info/exclude` + global excludes); disable with `respect_gitignore=false` or `LOGOSDB_RESPECT_GITIGNORE=0`. ' +
       'Supports any UTF-8 text file (source code, markdown, plain text). ' +
       'With incremental=true, skips files unchanged since last index (mtime+size+chunk_size), re-indexes modified files after deleting their previous chunk rows, and when indexing a directory removes DB rows for files that disappeared from disk.',
     inputSchema: {
@@ -116,6 +118,11 @@ const TOOLS: Tool[] = [
           description:
             'If true, only index new or changed files (vs last run in this namespace); delete old chunks for changed or removed files. Default false (full re-chunk of every file, may duplicate rows).',
         },
+        respect_gitignore: {
+          type: 'boolean',
+          description:
+            'Skip files matched by `.gitignore` rules of the enclosing Git working tree (root + nested + `.git/info/exclude` + global excludes). Default: true when `.git` is detected, else no-op. Set false to fall back to the legacy SKIP_DIRS + extension filters only. Env override: `LOGOSDB_RESPECT_GITIGNORE=0`.',
+        },
       },
       required: ['path', 'namespace'],
     },
@@ -133,11 +140,13 @@ const TOOLS: Tool[] = [
         top_k: { type: 'number', description: 'Number of results to return (default: 5)' },
         ts_from: {
           type: 'string',
-          description: 'Optional inclusive lower bound (ISO 8601). Omit with no `ts_to` for full-range search.',
+          description:
+            'Optional inclusive lower bound (ISO 8601). Omit with no `ts_to` for full-range search.',
         },
         ts_to: {
           type: 'string',
-          description: 'Optional inclusive upper bound (ISO 8601). Omit with no `ts_from` for full-range search.',
+          description:
+            'Optional inclusive upper bound (ISO 8601). Omit with no `ts_from` for full-range search.',
         },
         candidate_k: {
           type: 'number',
@@ -232,6 +241,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           CHUNK_SIZE,
         );
         const incremental = Boolean(args.incremental);
+        const respectGitignore =
+          args.respect_gitignore === undefined
+            ? respectGitignoreDefault()
+            : Boolean(args.respect_gitignore);
 
         if (!inputPath) throw new Error('"path" is required');
         if (!namespace) throw new Error('"namespace" is required');
@@ -240,7 +253,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         const absPath = resolveIndexablePath(inputPath);
         const stat = fs.statSync(absPath);
-        const filesToIndex = stat.isDirectory() ? collectFilesSafe(absPath) : [absPath];
+        const filesToIndex = stat.isDirectory()
+          ? collectFilesSafe(absPath, { respectGitignore })
+          : [absPath];
 
         if (filesToIndex.length === 0) {
           return ok({
@@ -249,6 +264,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             namespace,
             path: absPath,
             incremental,
+            respect_gitignore: respectGitignore,
             skipped_files: 0,
             indexed_files: 0,
             pruned_files: 0,
@@ -358,6 +374,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           namespace,
           path: absPath,
           incremental,
+          respect_gitignore: respectGitignore,
           skipped_files: incremental ? skippedFiles : 0,
           indexed_files: indexedFiles,
           pruned_files: incremental ? prunedFiles : 0,
@@ -477,7 +494,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           try {
             db = store.get(namespace);
             if (vec.length !== db.dim()) {
-              throw new Error(`Embedding dimension ${vec.length} does not match namespace dim ${db.dim()}`);
+              throw new Error(
+                `Embedding dimension ${vec.length} does not match namespace dim ${db.dim()}`,
+              );
             }
           } catch {
             const nsPath = path.join(LOGOSDB_PATH, namespace);
@@ -513,7 +532,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         try {
           db = store.get(namespace);
         } catch {
-          throw new Error(`Namespace "${namespace}" is not open. Index or search in it first (or use \`query\` delete).`);
+          throw new Error(
+            `Namespace "${namespace}" is not open. Index or search in it first (or use \`query\` delete).`,
+          );
         }
         const id = typeof args.id === 'number' ? args.id : parseInt(String(args.id), 10);
         if (isNaN(id)) throw new Error('"id" must be a number');

--- a/mcp/src/security.ts
+++ b/mcp/src/security.ts
@@ -6,6 +6,15 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import {
+  buildGitignoreContext,
+  findGitRoot,
+  isIgnoredByStack,
+  maybePushLocalGitignore,
+  type GitignoreContext,
+  type IgnoreFrame,
+} from './gitignore-walker';
+
 /** Max UTF-16 code units for indexed text or search query. */
 export const MAX_TEXT_CHARS = 512 * 1024;
 export const MAX_METADATA_CHARS = 32 * 1024;
@@ -120,11 +129,32 @@ export function resolveIndexablePath(userPath: string): string {
   );
 }
 
-export function collectFilesSafe(rootDirReal: string): string[] {
+export interface CollectFilesOptions {
+  /**
+   * When true, honour `.gitignore` (root + nested + `.git/info/exclude` + global
+   * excludes) **in addition to** the static `SKIP_DIRS` / hidden / extension
+   * filters. If no enclosing Git working tree is found (walking up to
+   * `process.cwd()` / `LOGOSDB_INDEX_ROOT`), this option is a no-op.
+   * Default: `false` (callers in `index.ts` derive a default per-call).
+   */
+  respectGitignore?: boolean;
+}
+
+export function collectFilesSafe(rootDirReal: string, options: CollectFilesOptions = {}): string[] {
   const rootReal = fs.realpathSync.native(rootDirReal);
   const results: string[] = [];
 
-  function walk(dir: string): void {
+  let gitignore: GitignoreContext | null = null;
+  if (options.respectGitignore) {
+    const gitRoot = findGitRoot(rootReal, indexRoots());
+    if (gitRoot !== null) {
+      gitignore = buildGitignoreContext(gitRoot);
+    }
+  }
+
+  function walk(dir: string, stack: IgnoreFrame[]): void {
+    const localStack = gitignore ? maybePushLocalGitignore(stack, dir) : stack;
+
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -135,6 +165,11 @@ export function collectFilesSafe(rootDirReal: string): string[] {
       if (entry.name.startsWith('.') && entry.isDirectory()) continue;
       if (SKIP_DIRS.has(entry.name)) continue;
       const full = path.join(dir, entry.name);
+
+      if (gitignore && localStack.length > 0) {
+        if (isIgnoredByStack(localStack, full, entry.isDirectory())) continue;
+      }
+
       let entryReal: string;
       try {
         entryReal = fs.realpathSync.native(full);
@@ -144,14 +179,14 @@ export function collectFilesSafe(rootDirReal: string): string[] {
       if (!isInsideRoot(entryReal, rootReal)) continue;
 
       if (entry.isDirectory()) {
-        walk(full);
+        walk(full, localStack);
       } else if (entry.isFile() && INDEXABLE_EXTENSIONS.has(path.extname(entry.name))) {
         results.push(entryReal);
       }
     }
   }
 
-  walk(rootDirReal);
+  walk(rootDirReal, gitignore ? gitignore.rootStack : []);
   return results;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,13 @@
     },
     "mcp": {
       "name": "logosdb-mcp-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xenova/transformers": "^2.17.2",
-        "logosdb": "^0.8.0"
+        "ignore": "^7.0.5",
+        "logosdb": "^0.9.0"
       },
       "bin": {
         "logosdb-mcp-server": "dist/index.js"
@@ -39,28 +40,13 @@
         "node": ">=18.0.0"
       }
     },
-    "mcp/node_modules/logosdb": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/logosdb/-/logosdb-0.8.0.tgz",
-      "integrity": "sha512-duCmDGgD11iblyAIiOqLsZcIaxyNSOraOQMV5O43NwPovPGrsCgiWZSUF+Z24bh532Rty6SgX6l+dVDptxS4qA==",
-      "cpu": [
-        "x64",
-        "arm64"
-      ],
-      "hasInstallScript": true,
+    "mcp/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "npm:@mmomtchev/prebuild-install@^1.0.2"
-      },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">= 4"
       }
     },
     "n8n": {


### PR DESCRIPTION
## Summary

`logosdb_index_file` now consults the enclosing Git working tree's ignore rules when walking a directory, in addition to the existing `SKIP_DIRS` / hidden / extension filters. This stops generated, vendored, or otherwise ignored files (e.g. `src/generated/**`, lockfiles, `*.cache/`, build outputs) from being embedded into namespaces just because they happen to live in a non-skipped directory with an indexable extension. Behaviour is **on by default** when a `.git/` dir is detected and is a **no-op** when no Git working tree is found — non-Git projects see no change.

Closes #101

## Changes

- [x] New module `mcp/src/gitignore-walker.ts` — discovers the enclosing `.git` (bounded by `process.cwd()` / `LOGOSDB_INDEX_ROOT`) and composes ignore frames from:
  - the working tree's root `.gitignore`,
  - every nested `.gitignore` discovered during the walk (per-directory scope),
  - `.git/info/exclude`,
  - the global excludes file (`$XDG_CONFIG_HOME/git/ignore`, falling back to `~/.config/git/ignore`).
- [x] `collectFilesSafe(rootDir, { respectGitignore })` in `mcp/src/security.ts` applies the stack per entry (file or dir) on top of the legacy filters.
- [x] `logosdb_index_file` tool gains a `respect_gitignore` argument (default-on when `.git/` is found). Env override: `LOGOSDB_RESPECT_GITIGNORE` (`0` / `false` / `no` / `off` disable). Tool response now echoes `respect_gitignore` so callers can confirm what was applied.
- [x] Pattern semantics (`!negation`, `**`, leading `/`, trailing `/`) delegated to the [`ignore`](https://www.npmjs.com/package/ignore) npm package (Git-spec compatible).
- [x] 13 new tests in `mcp/src/gitignore-walker.test.ts` covering nested rules, negation, `.git/info/exclude`, env override, the no-`.git` fallback, and the legacy default.
- [x] Docs: new "`.gitignore`-aware walking" section + env-var row in `mcp/README.md`; tool-table cell updated in the main `README.md`.
- [x] `CHANGELOG`: new `0.9.1 (unreleased)` MCP-only entry.
- [x] Drive-by: re-pin `logosdb` to `^0.9.0` in `mcp/package.json` (was stale `^0.8.0`).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass
- [x] Manual testing performed

Describe the tests you ran:

```bash
npm run build -w logosdb-mcp-server   # tsc clean
npm test       -w logosdb-mcp-server   # 24/24 pass + stdio smoke ok
npm run lint   -w logosdb-mcp-server   # eslint clean
npm run format:check -w logosdb-mcp-server   # prettier clean