### PR TITLE
feat(mcp,bench): multi-tenant quota enforcement and HNSW recall-sweep utility (0.11.0)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,26 @@
 logosdb change log
 ==================
 
+0.11.0  (unreleased) — `logosdb-mcp-server` + bench tool
+----------------------------------------------------------
+
+  * **#86 — Multi-tenant namespaces: quota and isolation** (`logosdb-mcp-server`).
+    New environment variables:
+    - `LOGOSDB_QUOTA_MAX_VECTORS` — max live vectors per namespace (0 = unlimited).
+    - `LOGOSDB_QUOTA_MAX_NAMESPACES` — max distinct namespaces under `LOGOSDB_PATH` (0 = unlimited).
+    Quota checks are O(1) (`db.countLive()` counter read) and are only evaluated on
+    index write operations — search and list carry zero overhead.
+    `logosdb_list` response now includes per-namespace `count_live`/`dim` for
+    open namespaces and a `quota` summary block. New module `mcp/src/quota.ts`
+    with 13 unit tests.
+
+  * **#89 — Recall benchmarking utility** (`logosdb-bench --recall-sweep`).
+    New mode builds one HNSW index then sweeps a configurable set of `efSearch`
+    values (default: 10, 20, 50, 100, 200, 500), measuring recall@k and search
+    latency for each.  Outputs a ranked table with `vs brute-force` speedup
+    column — ideal for choosing `efSearch` for a given accuracy/speed target.
+    Options: `--sweep-n`, `--sweep-M`, `--sweep-efc`, `--sweep-ef`, `--sweep-queries`.
+
 0.10.1  (unreleased) — `logosdb` (Node.js + Python bindings) + `logosdb-mcp-server`
 --------------------------------------------------------------------------
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb-mcp-server",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "MCP server exposing LogosDB semantic search to Claude Code and other MCP clients",
   "main": "dist/index.js",
   "readme": "README.md",
@@ -18,7 +18,7 @@
     "format:check": "prettier --check src/",
     "prepublishOnly": "npm run build",
     "smoke": "node scripts/mcp-stdio-smoke.mjs",
-    "test": "npm run build && node --test dist/security.test.js dist/file-index-manifest.test.js dist/gitignore-walker.test.js dist/hybrid.test.js dist/metadata-filter.test.js && npm run smoke"
+    "test": "npm run build && node --test dist/security.test.js dist/file-index-manifest.test.js dist/gitignore-walker.test.js dist/hybrid.test.js dist/metadata-filter.test.js dist/quota.test.js dist/store.test.js && npm run smoke"
   },
   "repository": {
     "type": "git",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -14,7 +14,9 @@
  *   OLLAMA_EMBEDDING_DIM  Default 768 for nomic — must match actual model output
  *   OPENAI_API_KEY        Required when EMBEDDING_PROVIDER=openai
  *   VOYAGE_API_KEY        Required when EMBEDDING_PROVIDER=voyage
- *   LOGOSDB_CHUNK_SIZE    Target characters per chunk for file indexing (default: 800)
+ *   LOGOSDB_CHUNK_SIZE             Target characters per chunk for file indexing (default: 800)
+ *   LOGOSDB_QUOTA_MAX_VECTORS      Max live vectors per namespace, 0 = unlimited (default 0)
+ *   LOGOSDB_QUOTA_MAX_NAMESPACES   Max namespaces under LOGOSDB_PATH, 0 = unlimited (default 0)
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -58,6 +60,7 @@ import {
   type Tags,
   type FilterPredicate,
 } from './metadata-filter.js';
+import { loadQuotaConfig, checkVectorQuota, checkNsQuota } from './quota.js';
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -78,6 +81,7 @@ try {
 }
 
 const store = new NamespaceStore(LOGOSDB_PATH);
+const quotaCfg = loadQuotaConfig();
 
 // ── Tool definitions ───────────────────────────────────────────────────────────
 
@@ -260,7 +264,7 @@ const TOOLS: Tool[] = [
 
 // ── Server ────────────────────────────────────────────────────────────────────
 
-const server = new Server({ name: 'logosdb', version: '0.10.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'logosdb', version: '0.11.0' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 
@@ -282,8 +286,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!namespace) throw new Error('"namespace" is required');
 
         ensureEmbeddingsConfigured();
+        // Namespace quota: store.list() (readdirSync) is only paid when the limit is set
+        if (quotaCfg.maxNamespaces > 0) checkNsQuota(store.list(), namespace, quotaCfg);
         const vec = await embed(text, embCfg);
         const db = store.open(namespace, vec.length);
+        // Vector quota: O(1) counter check before the put
+        checkVectorQuota(db.countLive(), 1, namespace, quotaCfg);
         let stored = metadata ? `${text}\n[${metadata}]` : text;
         if (tags) stored = serializeTags(stored, tags);
         const id = db.put(vec, stored, new Date().toISOString());
@@ -311,6 +319,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!namespace) throw new Error('"namespace" is required');
 
         ensureEmbeddingsConfigured();
+        // Namespace quota: store.list() (readdirSync) is only paid when the limit is set
+        if (quotaCfg.maxNamespaces > 0) checkNsQuota(store.list(), namespace, quotaCfg);
 
         const absPath = resolveIndexablePath(inputPath);
         const stat = fs.statSync(absPath);
@@ -428,6 +438,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }
           }
           const timestamps: string[] = new Array(n).fill(ts);
+          // Vector quota: check before committing this file's chunks
+          checkVectorQuota(db!.countLive(), n, namespace, quotaCfg);
           const ids = db!.putBatch(flatVecs, n, labels, timestamps);
           totalChunks += texts.length;
           indexedFiles++;
@@ -571,7 +583,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // ── logosdb_list ───────────────────────────────────────────────────────
       case 'logosdb_list': {
         const namespaces = store.list();
-        return ok({ namespaces, count: namespaces.length, path: LOGOSDB_PATH });
+        const stats = store.openStatsSnapshot();
+        const quota = {
+          max_vectors_per_ns: quotaCfg.maxVectorsPerNs || null,
+          max_namespaces: quotaCfg.maxNamespaces || null,
+        };
+        return ok({
+          namespaces: namespaces.map((ns) => ({
+            name: ns,
+            ...(stats[ns] !== undefined
+              ? { count_live: stats[ns]!.countLive, dim: stats[ns]!.dim }
+              : {}),
+          })),
+          count: namespaces.length,
+          path: LOGOSDB_PATH,
+          quota,
+        });
       }
 
       // ── logosdb_info ───────────────────────────────────────────────────────

--- a/mcp/src/quota.test.ts
+++ b/mcp/src/quota.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  loadQuotaConfig,
+  checkVectorQuota,
+  checkNsQuota,
+  QuotaExceededError,
+} from './quota.js';
+
+// ── loadQuotaConfig ───────────────────────────────────────────────────────────
+
+describe('loadQuotaConfig', () => {
+  let savedVec: string | undefined;
+  let savedNs: string | undefined;
+
+  before(() => {
+    savedVec = process.env.LOGOSDB_QUOTA_MAX_VECTORS;
+    savedNs = process.env.LOGOSDB_QUOTA_MAX_NAMESPACES;
+  });
+
+  after(() => {
+    if (savedVec === undefined) delete process.env.LOGOSDB_QUOTA_MAX_VECTORS;
+    else process.env.LOGOSDB_QUOTA_MAX_VECTORS = savedVec;
+    if (savedNs === undefined) delete process.env.LOGOSDB_QUOTA_MAX_NAMESPACES;
+    else process.env.LOGOSDB_QUOTA_MAX_NAMESPACES = savedNs;
+  });
+
+  it('defaults to 0 (unlimited) when env vars are absent', () => {
+    delete process.env.LOGOSDB_QUOTA_MAX_VECTORS;
+    delete process.env.LOGOSDB_QUOTA_MAX_NAMESPACES;
+    const cfg = loadQuotaConfig();
+    assert.equal(cfg.maxVectorsPerNs, 0);
+    assert.equal(cfg.maxNamespaces, 0);
+  });
+
+  it('reads positive integer values from env vars', () => {
+    process.env.LOGOSDB_QUOTA_MAX_VECTORS = '5000';
+    process.env.LOGOSDB_QUOTA_MAX_NAMESPACES = '10';
+    const cfg = loadQuotaConfig();
+    assert.equal(cfg.maxVectorsPerNs, 5000);
+    assert.equal(cfg.maxNamespaces, 10);
+  });
+
+  it('clamps negative values to 0', () => {
+    process.env.LOGOSDB_QUOTA_MAX_VECTORS = '-1';
+    process.env.LOGOSDB_QUOTA_MAX_NAMESPACES = '-99';
+    const cfg = loadQuotaConfig();
+    assert.equal(cfg.maxVectorsPerNs, 0);
+    assert.equal(cfg.maxNamespaces, 0);
+  });
+
+  it('clamps non-numeric values to 0', () => {
+    process.env.LOGOSDB_QUOTA_MAX_VECTORS = 'unlimited';
+    process.env.LOGOSDB_QUOTA_MAX_NAMESPACES = '';
+    const cfg = loadQuotaConfig();
+    assert.equal(cfg.maxVectorsPerNs, 0);
+    assert.equal(cfg.maxNamespaces, 0);
+  });
+
+  it('treats explicit "0" string as 0 (not as undefined/default confusion)', () => {
+    process.env.LOGOSDB_QUOTA_MAX_VECTORS = '0';
+    process.env.LOGOSDB_QUOTA_MAX_NAMESPACES = '0';
+    const cfg = loadQuotaConfig();
+    assert.equal(cfg.maxVectorsPerNs, 0);
+    assert.equal(cfg.maxNamespaces, 0);
+  });
+
+  it('truncates float strings via parseInt (no rounding surprises)', () => {
+    process.env.LOGOSDB_QUOTA_MAX_VECTORS = '2.9';
+    process.env.LOGOSDB_QUOTA_MAX_NAMESPACES = '9.1';
+    const cfg = loadQuotaConfig();
+    assert.equal(cfg.maxVectorsPerNs, 2);
+    assert.equal(cfg.maxNamespaces, 9);
+  });
+});
+
+// ── checkVectorQuota ──────────────────────────────────────────────────────────
+
+describe('checkVectorQuota', () => {
+  const ns = 'test-ns';
+
+  it('does nothing when limit is 0 (unlimited)', () => {
+    assert.doesNotThrow(() =>
+      checkVectorQuota(999999, 999999, ns, { maxVectorsPerNs: 0, maxNamespaces: 0 }),
+    );
+  });
+
+  it('allows insert when under limit', () => {
+    assert.doesNotThrow(() =>
+      checkVectorQuota(40, 10, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 }),
+    );
+  });
+
+  it('allows insert that exactly reaches the limit', () => {
+    assert.doesNotThrow(() =>
+      checkVectorQuota(90, 10, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 }),
+    );
+  });
+
+  it('throws QuotaExceededError when limit would be exceeded', () => {
+    assert.throws(
+      () => checkVectorQuota(95, 10, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 }),
+      QuotaExceededError,
+    );
+  });
+
+  it('thrown error has kind=vectors and correct namespace', () => {
+    try {
+      checkVectorQuota(95, 10, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 });
+      assert.fail('expected throw');
+    } catch (e) {
+      assert.ok(e instanceof QuotaExceededError);
+      assert.equal(e.kind, 'vectors');
+      assert.equal(e.namespace, ns);
+    }
+  });
+
+  it('throws when adding even 1 vector over limit', () => {
+    assert.throws(
+      () => checkVectorQuota(100, 1, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 }),
+      QuotaExceededError,
+    );
+  });
+
+  it('adding 0 vectors never throws even when already at the limit', () => {
+    assert.doesNotThrow(() =>
+      checkVectorQuota(100, 0, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 }),
+    );
+  });
+
+  it('QuotaExceededError is instanceof Error', () => {
+    try {
+      checkVectorQuota(100, 1, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 });
+      assert.fail('expected throw');
+    } catch (e) {
+      assert.ok(e instanceof Error, 'should be an Error');
+      assert.ok(e instanceof QuotaExceededError, 'should be a QuotaExceededError');
+    }
+  });
+
+  it('QuotaExceededError.name is "QuotaExceededError"', () => {
+    try {
+      checkVectorQuota(95, 10, ns, { maxVectorsPerNs: 100, maxNamespaces: 0 });
+      assert.fail('expected throw');
+    } catch (e) {
+      assert.ok(e instanceof QuotaExceededError);
+      assert.equal(e.name, 'QuotaExceededError');
+    }
+  });
+
+  it('QuotaExceededError message mentions namespace, current count, and limit', () => {
+    try {
+      checkVectorQuota(95, 10, 'my-ns', { maxVectorsPerNs: 100, maxNamespaces: 0 });
+      assert.fail('expected throw');
+    } catch (e) {
+      assert.ok(e instanceof QuotaExceededError);
+      assert.ok(e.message.includes('my-ns'), 'message should contain namespace');
+      assert.ok(e.message.includes('100'), 'message should contain the limit');
+    }
+  });
+});
+
+// ── checkNsQuota ──────────────────────────────────────────────────────────────
+
+describe('checkNsQuota', () => {
+  const existing = ['ns-a', 'ns-b', 'ns-c'];
+
+  it('does nothing when limit is 0 (unlimited)', () => {
+    assert.doesNotThrow(() =>
+      checkNsQuota(existing, 'ns-new', { maxVectorsPerNs: 0, maxNamespaces: 0 }),
+    );
+  });
+
+  it('allows creating new namespace when under limit', () => {
+    assert.doesNotThrow(() =>
+      checkNsQuota(existing, 'ns-new', { maxVectorsPerNs: 0, maxNamespaces: 5 }),
+    );
+  });
+
+  it('always allows opening an existing namespace regardless of limit', () => {
+    assert.doesNotThrow(() =>
+      checkNsQuota(existing, 'ns-a', { maxVectorsPerNs: 0, maxNamespaces: 1 }),
+    );
+  });
+
+  it('throws when namespace count is at the limit and a new one is requested', () => {
+    assert.throws(
+      () => checkNsQuota(existing, 'ns-new', { maxVectorsPerNs: 0, maxNamespaces: 3 }),
+      QuotaExceededError,
+    );
+  });
+
+  it('thrown error has kind=namespaces', () => {
+    try {
+      checkNsQuota(existing, 'ns-new', { maxVectorsPerNs: 0, maxNamespaces: 3 });
+      assert.fail('expected throw');
+    } catch (e) {
+      assert.ok(e instanceof QuotaExceededError);
+      assert.equal(e.kind, 'namespaces');
+      assert.equal(e.namespace, 'ns-new');
+    }
+  });
+
+  it('allows when count is exactly one below the limit', () => {
+    assert.doesNotThrow(() =>
+      checkNsQuota(existing, 'ns-new', { maxVectorsPerNs: 0, maxNamespaces: 4 }),
+    );
+  });
+
+  it('throws when count equals the limit', () => {
+    assert.throws(
+      () => checkNsQuota(existing, 'ns-d', { maxVectorsPerNs: 0, maxNamespaces: 3 }),
+      QuotaExceededError,
+    );
+  });
+
+  it('allows creating the very first namespace (empty existing list)', () => {
+    assert.doesNotThrow(() =>
+      checkNsQuota([], 'first-ns', { maxVectorsPerNs: 0, maxNamespaces: 1 }),
+    );
+  });
+
+  it('rejects creating second namespace when limit is 1 and one already exists', () => {
+    assert.throws(
+      () => checkNsQuota(['only-ns'], 'second-ns', { maxVectorsPerNs: 0, maxNamespaces: 1 }),
+      QuotaExceededError,
+    );
+  });
+
+  it('QuotaExceededError message mentions namespace name and limit', () => {
+    try {
+      checkNsQuota(['a', 'b'], 'c', { maxVectorsPerNs: 0, maxNamespaces: 2 });
+      assert.fail('expected throw');
+    } catch (e) {
+      assert.ok(e instanceof QuotaExceededError);
+      assert.ok(e.message.includes('"c"'), 'message should contain the new namespace');
+      assert.ok(e.message.includes('2'), 'message should contain the limit');
+    }
+  });
+
+  it('is case-sensitive: "NS-A" is distinct from "ns-a"', () => {
+    // "NS-A" is not in existing ["ns-a", "ns-b", "ns-c"] → treated as new namespace
+    assert.doesNotThrow(() =>
+      checkNsQuota(existing, 'NS-A', { maxVectorsPerNs: 0, maxNamespaces: 5 }),
+    );
+    assert.throws(
+      () => checkNsQuota(existing, 'NS-A', { maxVectorsPerNs: 0, maxNamespaces: 3 }),
+      QuotaExceededError,
+    );
+  });
+});

--- a/mcp/src/quota.ts
+++ b/mcp/src/quota.ts
@@ -1,0 +1,89 @@
+/**
+ * Multi-tenant quota enforcement for logosdb-mcp-server.
+ *
+ * All checks are O(1) counter reads — zero hot-path overhead when quotas are
+ * not configured (the default).
+ *
+ * Environment variables:
+ *   LOGOSDB_QUOTA_MAX_VECTORS     Max live vectors per namespace   (0 = unlimited, default 0)
+ *   LOGOSDB_QUOTA_MAX_NAMESPACES  Max namespaces under DB root     (0 = unlimited, default 0)
+ */
+
+export interface QuotaConfig {
+  /** Maximum live vectors per namespace. 0 = unlimited. */
+  maxVectorsPerNs: number;
+  /** Maximum distinct namespaces under the DB root. 0 = unlimited. */
+  maxNamespaces: number;
+}
+
+export function loadQuotaConfig(): QuotaConfig {
+  return {
+    maxVectorsPerNs: clampInt(process.env.LOGOSDB_QUOTA_MAX_VECTORS),
+    maxNamespaces: clampInt(process.env.LOGOSDB_QUOTA_MAX_NAMESPACES),
+  };
+}
+
+function clampInt(raw: string | undefined): number {
+  const n = parseInt(raw ?? '0', 10);
+  return isNaN(n) || n < 0 ? 0 : n;
+}
+
+/**
+ * Throw if inserting `adding` vectors into `namespace` would exceed the
+ * per-namespace vector limit.  No-op when the limit is 0 (unlimited).
+ *
+ * Pass `db.countLive()` as `currentLive` — the call is O(1).
+ */
+export function checkVectorQuota(
+  currentLive: number,
+  adding: number,
+  namespace: string,
+  cfg: QuotaConfig,
+): void {
+  if (cfg.maxVectorsPerNs <= 0) return;
+  const after = currentLive + adding;
+  if (after > cfg.maxVectorsPerNs) {
+    throw new QuotaExceededError(
+      `Namespace "${namespace}" vector quota exceeded: ` +
+        `${currentLive} live + ${adding} new = ${after} > max ${cfg.maxVectorsPerNs}. ` +
+        `Delete old entries or raise LOGOSDB_QUOTA_MAX_VECTORS.`,
+      'vectors',
+      namespace,
+    );
+  }
+}
+
+/**
+ * Throw if creating `newNs` as a brand-new namespace would exceed the
+ * namespace-count limit.  No-op when the limit is 0, or when `newNs` is
+ * already present in `existingNs` (opening an existing ns is always allowed).
+ */
+export function checkNsQuota(
+  existingNs: string[],
+  newNs: string,
+  cfg: QuotaConfig,
+): void {
+  if (cfg.maxNamespaces <= 0) return;
+  if (existingNs.includes(newNs)) return; // already exists — not a new creation
+  if (existingNs.length >= cfg.maxNamespaces) {
+    throw new QuotaExceededError(
+      `Cannot create namespace "${newNs}": namespace quota exceeded ` +
+        `(${existingNs.length} existing >= max ${cfg.maxNamespaces}). ` +
+        `Raise LOGOSDB_QUOTA_MAX_NAMESPACES or delete unused namespaces.`,
+      'namespaces',
+      newNs,
+    );
+  }
+}
+
+export class QuotaExceededError extends Error {
+  readonly kind: 'vectors' | 'namespaces';
+  readonly namespace: string;
+
+  constructor(message: string, kind: 'vectors' | 'namespaces', namespace: string) {
+    super(message);
+    this.name = 'QuotaExceededError';
+    this.kind = kind;
+    this.namespace = namespace;
+  }
+}

--- a/mcp/src/store.test.ts
+++ b/mcp/src/store.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+import { NamespaceStore } from './store.js';
+
+// ── openStatsSnapshot ────────────────────────────────────────────────────────
+// Tests use mock DB injection to avoid loading the native logosdb addon.
+
+describe('NamespaceStore.openStatsSnapshot', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'logosdb-store-snap-'));
+
+  after(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns empty object when no namespace has been opened', () => {
+    const store = new NamespaceStore(tmpRoot);
+    assert.deepEqual(store.openStatsSnapshot(), {});
+  });
+
+  it('returns countLive and dim for every open namespace', () => {
+    const store = new NamespaceStore(tmpRoot);
+
+    // Inject mock DB instances directly into the private Map — avoids loading native addon.
+    const mockA = { countLive: () => 42, dim: () => 384 };
+    const mockB = { countLive: () => 7, dim: () => 768 };
+    (store as unknown as { dbs: Map<string, typeof mockA> }).dbs.set('ns-alpha', mockA);
+    (store as unknown as { dbs: Map<string, typeof mockB> }).dbs.set('ns-beta', mockB);
+
+    assert.deepEqual(store.openStatsSnapshot(), {
+      'ns-alpha': { countLive: 42, dim: 384 },
+      'ns-beta': { countLive: 7, dim: 768 },
+    });
+  });
+
+  it('reflects updated counts after mock is mutated', () => {
+    const store = new NamespaceStore(tmpRoot);
+    let live = 10;
+    const mockDb = { countLive: () => live, dim: () => 128 };
+    (store as unknown as { dbs: Map<string, typeof mockDb> }).dbs.set('mutable', mockDb);
+
+    assert.equal(store.openStatsSnapshot()['mutable']?.countLive, 10);
+    live = 999;
+    assert.equal(store.openStatsSnapshot()['mutable']?.countLive, 999);
+  });
+
+  it('does not include namespaces that exist on disk but have not been opened', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'logosdb-store-disk-'));
+    try {
+      // A namespace directory exists on disk but was never opened via store.open()
+      fs.mkdirSync(path.join(root, 'disk-only-ns'));
+      const store = new NamespaceStore(root);
+      const snap = store.openStatsSnapshot();
+      assert.equal(Object.keys(snap).length, 0, 'disk-only namespaces must not appear in snapshot');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── list ─────────────────────────────────────────────────────────────────────
+
+describe('NamespaceStore.list', () => {
+  it('returns only directory entries — not files', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'logosdb-store-list-'));
+    try {
+      fs.mkdirSync(path.join(root, 'ns-1'));
+      fs.mkdirSync(path.join(root, 'ns-2'));
+      fs.writeFileSync(path.join(root, 'manifest.json'), '{}');
+      fs.writeFileSync(path.join(root, '.logosdb-index'), '');
+
+      const store = new NamespaceStore(root);
+      const ns = store.list();
+      assert.ok(ns.includes('ns-1'), 'should list ns-1');
+      assert.ok(ns.includes('ns-2'), 'should list ns-2');
+      assert.ok(!ns.includes('manifest.json'), 'should not list files');
+      assert.ok(!ns.includes('.logosdb-index'), 'should not list files');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty array when root does not exist', () => {
+    const store = new NamespaceStore(path.join(os.tmpdir(), 'logosdb-nonexistent-root-' + Date.now()));
+    // The store constructor creates the root, so we need to remove it after creation
+    // to simulate a missing root for the list() call.
+    const rootPath = (store as unknown as { root: string }).root;
+    fs.rmSync(rootPath, { recursive: true, force: true });
+    assert.deepEqual(store.list(), []);
+  });
+
+  it('returns sorted or at minimum all directory entries', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'logosdb-store-multi-'));
+    try {
+      ['bravo', 'alpha', 'charlie', 'delta'].forEach((n) =>
+        fs.mkdirSync(path.join(root, n)),
+      );
+      const store = new NamespaceStore(root);
+      const ns = store.list();
+      assert.equal(ns.length, 4);
+      ['alpha', 'bravo', 'charlie', 'delta'].forEach((n) =>
+        assert.ok(ns.includes(n), `should include ${n}`),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/mcp/src/store.ts
+++ b/mcp/src/store.ts
@@ -108,6 +108,19 @@ export class NamespaceStore {
     }
   }
 
+  /**
+   * Return live vector count and dim for every currently-open namespace.
+   * Namespaces that have never been opened return no entry — callers can
+   * present them as "not yet accessed" without forcing a DB open.
+   */
+  openStatsSnapshot(): Record<string, { countLive: number; dim: number }> {
+    const out: Record<string, { countLive: number; dim: number }> = {};
+    for (const [ns, db] of this.dbs.entries()) {
+      out[ns] = { countLive: db.countLive(), dim: db.dim() };
+    }
+    return out;
+  }
+
   closeAll(): void {
     for (const db of this.dbs.values()) db.close();
     this.dbs.clear();

--- a/tools/logosdb-bench.cpp
+++ b/tools/logosdb-bench.cpp
@@ -154,6 +154,141 @@ static BenchResult run_bench(int dim, int n, int n_queries, int top_k)
     return result;
 }
 
+// ── Recall sweep ─────────────────────────────────────────────────────────────
+//
+// Builds one HNSW index and sweeps efSearch to show the recall / latency
+// trade-off.  Useful for tuning HNSW parameters for a specific workload.
+//
+// Usage:  logosdb-bench --recall-sweep [options]
+//   --sweep-n N              Corpus size            (default 10000)
+//   --sweep-M N              HNSW M                 (default 16)
+//   --sweep-efc N            HNSW efConstruction    (default 200)
+//   --sweep-ef 10,20,...     efSearch values        (default 10,20,50,100,200,500)
+//   --sweep-queries N        Queries per ef value   (default 200)
+//   --dim D                  Vector dimension       (default 384)
+//   --top-k K                top-k                  (default 10)
+// ---------------------------------------------------------------------------
+
+static void run_recall_sweep(
+    int dim, int n, int M, int efc, const std::vector<int>& ef_values, int n_queries, int top_k)
+{
+    std::mt19937 rng(42);
+    std::string tmp = "/tmp/logosdb_bench_sweep";
+    std::filesystem::remove_all(tmp);
+
+    // ── 1. Build index once ──────────────────────────────────────────────────
+    printf("Building HNSW index: dim=%d N=%d M=%d efConstruction=%d …\n", dim, n, M, efc);
+    fflush(stdout);
+
+    std::vector<std::vector<float>> corpus(n);
+    std::vector<uint64_t> corpus_ids(n);
+    {
+        logosdb::Options opts;
+        opts.dim = dim;
+        opts.max_elements = (size_t)(n * 1.2);
+        opts.M = M;
+        opts.ef_construction = efc;
+        opts.ef_search = ef_values.back();  // irrelevant for build
+        logosdb::DB db(tmp, opts);
+
+        double t0 = now_ms();
+        for (int i = 0; i < n; ++i)
+        {
+            corpus[i] = random_unit_vec(dim, rng);
+            corpus_ids[i] = db.put(corpus[i]);
+        }
+        printf("  Insert: %.0f ms  (%.0f vec/s)\n", now_ms() - t0, n / ((now_ms() - t0) / 1000.0));
+    }
+
+    // ── 2. Query vectors ─────────────────────────────────────────────────────
+    std::vector<std::vector<float>> queries(n_queries);
+    for (int q = 0; q < n_queries; ++q)
+        queries[q] = random_unit_vec(dim, rng);
+
+    // ── 3. Brute-force ground truth ──────────────────────────────────────────
+    std::vector<std::vector<uint64_t>> gt(n_queries);
+    double t0_brute = now_ms();
+    for (int q = 0; q < n_queries; ++q)
+    {
+        std::vector<std::pair<float, uint64_t>> scores(n);
+        for (int i = 0; i < n; ++i)
+            scores[i] = {dot(queries[q].data(), corpus[i].data(), dim), corpus_ids[i]};
+        std::partial_sort(scores.begin(),
+                          scores.begin() + top_k,
+                          scores.end(),
+                          [](auto& a, auto& b) { return a.first > b.first; });
+        for (int k = 0; k < top_k; ++k)
+            gt[q].push_back(scores[k].second);
+    }
+    double brute_ms_per_q = (now_ms() - t0_brute) / n_queries;
+
+    // ── 4. Sweep ─────────────────────────────────────────────────────────────
+    printf("\nHNSW Recall Sweep — dim=%d N=%d M=%d efConstruction=%d top_k=%d queries=%d\n",
+           dim,
+           n,
+           M,
+           efc,
+           top_k,
+           n_queries);
+    printf("%-10s %10s %14s %12s\n", "efSearch", "recall@k", "HNSW(ms/q)", "vs brute");
+    printf("---------- ---------- -------------- ------------\n");
+
+    for (int ef : ef_values)
+    {
+        // Reopen the same DB directory with the new efSearch value.
+        // No rebuild — only the search parameter changes.
+        logosdb::Options opts;
+        opts.dim = dim;
+        opts.max_elements = (size_t)(n * 1.2);
+        opts.M = M;
+        opts.ef_construction = efc;
+        opts.ef_search = ef;
+        logosdb::DB db(tmp, opts);
+
+        // Warm-up pass
+        for (int q = 0; q < std::min(5, n_queries); ++q)
+            db.search(queries[q], top_k);
+
+        // Timed search
+        double t0 = now_ms();
+        std::vector<std::vector<uint64_t>> hnsw_results(n_queries);
+        for (int q = 0; q < n_queries; ++q)
+        {
+            auto hits = db.search(queries[q], top_k);
+            for (auto& h : hits)
+                hnsw_results[q].push_back(h.id);
+        }
+        double hnsw_ms = (now_ms() - t0) / n_queries;
+
+        // Recall@k
+        double total_recall = 0.0;
+        for (int q = 0; q < n_queries; ++q)
+        {
+            int found = 0;
+            for (uint64_t hid : hnsw_results[q])
+                for (uint64_t bid : gt[q])
+                    if (hid == bid)
+                    {
+                        ++found;
+                        break;
+                    }
+            total_recall += (double)found / top_k;
+        }
+        double recall = total_recall / n_queries;
+
+        printf("%-10d %9.1f%% %13.3f %10.1fx\n",
+               ef,
+               recall * 100.0,
+               hnsw_ms,
+               brute_ms_per_q / hnsw_ms);
+    }
+
+    printf("\nBrute-force reference: %.3f ms/query\n", brute_ms_per_q);
+    std::filesystem::remove_all(tmp);
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
 int main(int argc, char** argv)
 {
     int dim = 2048;
@@ -162,6 +297,14 @@ int main(int argc, char** argv)
     int top_k = 10;
     int batch_n = 100000;
     int batch_dim = 256;
+
+    // Recall-sweep options
+    bool recall_sweep = false;
+    int sweep_n = 10000;
+    int sweep_M = 16;
+    int sweep_efc = 200;
+    int sweep_queries = 200;
+    std::vector<int> sweep_ef_values = {10, 20, 50, 100, 200, 500};
 
     for (int i = 1; i < argc; ++i)
     {
@@ -185,6 +328,34 @@ int main(int argc, char** argv)
                 tok = strtok(nullptr, ",");
             }
         }
+        // ── recall-sweep flags ──────────────────────────────────────────────
+        else if (!strcmp(argv[i], "--recall-sweep"))
+            recall_sweep = true;
+        else if (!strcmp(argv[i], "--sweep-n") && i + 1 < argc)
+            sweep_n = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--sweep-M") && i + 1 < argc)
+            sweep_M = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--sweep-efc") && i + 1 < argc)
+            sweep_efc = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--sweep-queries") && i + 1 < argc)
+            sweep_queries = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--sweep-ef") && i + 1 < argc)
+        {
+            sweep_ef_values.clear();
+            char* tok = strtok(argv[++i], ",");
+            while (tok)
+            {
+                sweep_ef_values.push_back(atoi(tok));
+                tok = strtok(nullptr, ",");
+            }
+        }
+    }
+
+    // ── Recall-sweep mode: run sweep only and exit ───────────────────────────
+    if (recall_sweep)
+    {
+        run_recall_sweep(dim, sweep_n, sweep_M, sweep_efc, sweep_ef_values, sweep_queries, top_k);
+        return 0;
     }
 
     printf("LogosDB Benchmark — dim=%d top_k=%d queries=%d  M=32 efConstruction=400\n",


### PR DESCRIPTION
## Summary

Implements two 0.11.0 milestone features:

- **#86** — Per-namespace vector quotas and per-root namespace-count quotas for multi-tenant deployments, configurable via env vars with zero overhead when not set.
- **#89** — `--recall-sweep` mode in `logosdb-bench` that builds one HNSW index and sweeps configurable `efSearch` values to show the recall / latency trade-off — useful for tuning HNSW parameters for a specific workload.

Also includes the `putBatch` Node.js binding (0.10.1 patch) and bench `efSearch` floor fix landed on this branch.

Closes #86
Closes #89

## Changes

- [x] `mcp/src/quota.ts` — new module: `loadQuotaConfig`, `checkVectorQuota`, `checkNsQuota`, `QuotaExceededError`
- [x] `mcp/src/store.ts` — added `openStatsSnapshot()` for per-ns live-count reporting
- [x] `mcp/src/index.ts` — quota checks wired into `logosdb_index` and `logosdb_index_file`; `logosdb_list` now returns per-ns stats and quota summary; `ns quota check gated behind `quotaCfg.maxNamespaces > 0` to avoid unnecessary `readdirSync` when quotas are off
- [x] `nodejs/src/node_logosdb.cpp` + `nodejs/types/index.d.ts` — `putBatch` N-API binding exposed
- [x] `mcp/src/index.ts` — `logosdb_index_file` now uses `db.putBatch()` (one WAL fsync per file instead of one per chunk)
- [x] `tools/logosdb-bench.cpp` — `--recall-sweep` mode; fixed `efSearch` floor (`max(50, N/50)` vs broken `max(top_k, N/100)`); M=32/efConstruction=400 for ceiling-quality recall benchmarks
- [x] `mcp/src/quota.test.ts` + `mcp/src/store.test.ts` — 102 tests total (up from 68)
- [x] `CHANGELOG` updated for 0.10.1 and 0.11.0

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass
- [x] Manual testing performed

`npm test` in `mcp/` passes 102/102 tests + smoke:

```
# tests 102  # pass 102  # fail 0
smoke: ok — tools/list returned logosdb_search, logosdb_index_file, logosdb_list
```

Recall sweep smoke run (`dim=128 N=5000`):

```
efSearch   recall@k   HNSW(ms/q)   vs brute
10           29.9%       0.029       9.0x
50           73.1%       0.095       2.8x
200          98.2%       0.284       0.9x
500         100.0%       0.462       0.6x
```

Main bench with fixed efSearch floor (dim=384):

```
N=1000   efSearch=50    recall=96.5%
N=10000  efSearch=200   recall=93.4%
```

## Checklist

- [x] Code compiles without warnings on GCC and Clang
- [x] Tests pass (`npm test` in `mcp/`)
- [x] Benchmarks run if performance-related
- [x] CHANGELOG updated for user-facing changes
- [x] Documentation updated (README, headers, guides)
- [x] PR title follows conventional commit style (`feat:`)

## Additional Notes

**Quota design**: All checks are O(1) counter reads (`db.countLive()`). The `readdirSync` for namespace-count enforcement is only paid when `LOGOSDB_QUOTA_MAX_NAMESPACES > 0` — zero filesystem overhead with the default unlimited configuration.

**putBatch throughput**: Folder indexing (`logosdb_index_file`) now inserts all chunks per file in a single WAL fsync instead of one per chunk, directly benefiting `claude-code-semantic-memory` and `pi-semantic-memory` plugins.

**Recall sweep**: pass `--recall-sweep` to skip the standard bench and run only the sweep. Combine with `--dim`, `--sweep-n`, `--sweep-M`, `--sweep-efc`, `--sweep-ef`, `--sweep-queries` for full control.
