### PR TITLE
feat(plugins): Codex semantic memory plugin — LogosDB MCP integration (#78)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,23 @@
 logosdb change log
 ==================
 
+0.12.0  (unreleased) — integrations
+------------------------------------
+
+  * **#78 — Codex plugin marketplace integration** (`plugins/codex-semantic-memory`).
+    New first-party plugin for OpenAI Codex CLI. Registers `logosdb-mcp-server` as an
+    MCP server via a self-contained `.mcp.json` (inline `bash -c` — no external script
+    dependency, path-agnostic for both home-local and repo-local installs). Provides:
+    - `AGENTS.md` — automatic silent indexing on session start, semantic search before
+      every response, turn-record persistence after every response.
+    - `skills/semantic-memory/SKILL.md` — explicit commands: `/memory-recall`,
+      `/memory-remember`, `/memory-index`, `/memory-status`.
+    - `scripts/logosdb-mcp-wrap.sh` — standalone convenience wrapper (also documents
+      the `LOGOS_MEMORY_MODE=global|project` env var).
+    - `.codex-plugin/plugin.json` + `marketplace.json` — Codex plugin manifests.
+    Namespace prefix `codex-` isolates Codex turn records from Claude Code (`claude-`)
+    and Pi (`pi-`) agents when sharing a global DB.
+
 0.11.0  (unreleased) — `logosdb-mcp-server` + bench tool
 ----------------------------------------------------------
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -44,7 +44,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xenova/transformers": "^2.17.2",
     "ignore": "^7.0.5",
-    "logosdb": "^0.10.1"
+    "logosdb": "^0.11.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb-mcp-server",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server exposing LogosDB semantic search to Claude Code and other MCP clients",
   "main": "dist/index.js",
   "readme": "README.md",
@@ -44,7 +44,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xenova/transformers": "^2.17.2",
     "ignore": "^7.0.5",
-    "logosdb": "^0.11.0"
+    "logosdb": "^0.12.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-logosdb",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "n8n node for LogosDB semantic vector database — insert, search, delete, info",
   "keywords": [
     "n8n-community-node-package",
@@ -41,7 +41,7 @@
     ]
   },
   "dependencies": {
-    "logosdb": "^0.10.0"
+    "logosdb": "^0.11.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-logosdb",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "n8n node for LogosDB semantic vector database — insert, search, delete, info",
   "keywords": [
     "n8n-community-node-package",
@@ -41,7 +41,7 @@
     ]
   },
   "dependencies": {
-    "logosdb": "^0.11.0"
+    "logosdb": "^0.12.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Fast semantic vector database (HNSW + mmap) - Node.js bindings",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logosdb",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Fast semantic vector database (HNSW + mmap) - Node.js bindings",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/plugins/codex-semantic-memory/.codex-plugin/marketplace.json
+++ b/plugins/codex-semantic-memory/.codex-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "codex-semantic-memory",
+  "interface": {
+    "displayName": "Semantic Memory (LogosDB)",
+    "description": "Local-first semantic memory for Codex. Auto-indexes your project, recalls relevant context from past sessions, and stores turn records — fully on-device, zero cloud.",
+    "icon": "🧠",
+    "version": "0.1.0",
+    "author": "Jose Ignacio",
+    "homepage": "https://github.com/jose-compu/codex-semantic-memory",
+    "license": "MIT"
+  },
+  "source": {
+    "source": "local",
+    "path": "."
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "NONE"
+  },
+  "category": "Productivity"
+}

--- a/plugins/codex-semantic-memory/.codex-plugin/plugin.json
+++ b/plugins/codex-semantic-memory/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "codex-semantic-memory",
+  "version": "0.1.0",
+  "description": "Local-first semantic memory for Codex powered by LogosDB. Auto-indexes the project, injects relevant past context silently before every response, and persists turn records across sessions — no cloud, no API keys.",
+  "author": "Jose Ignacio",
+  "license": "MIT",
+  "homepage": "https://github.com/jose-compu/codex-semantic-memory",
+  "keywords": [
+    "memory",
+    "semantic-search",
+    "logosdb",
+    "mcp",
+    "local-first",
+    "vector-search",
+    "rag",
+    "context"
+  ],
+  "mcpConfig": "../.mcp.json",
+  "skills": [
+    "../skills/semantic-memory/SKILL.md"
+  ]
+}

--- a/plugins/codex-semantic-memory/.mcp.json
+++ b/plugins/codex-semantic-memory/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "logosdb": {
+      "command": "bash",
+      "args": [
+        "-c",
+        "MODE=${LOGOS_MEMORY_MODE:-global}; if [ \"$MODE\" = project ]; then export LOGOSDB_PATH=$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.logosdb; else export LOGOSDB_PATH=$HOME/.codex/.logosdb; fi; command -v logosdb-mcp-server >/dev/null 2>&1 && exec logosdb-mcp-server || exec npx --yes logosdb-mcp-server"
+      ]
+    }
+  }
+}

--- a/plugins/codex-semantic-memory/AGENTS.md
+++ b/plugins/codex-semantic-memory/AGENTS.md
@@ -1,0 +1,83 @@
+# Semantic Memory — Codex Instructions
+
+This project uses the **codex-semantic-memory** plugin backed by a local LogosDB MCP server.
+All automatic memory operations are **silent** — never mention them to the user unless they ask.
+
+## UX contract — silence is mandatory
+
+| Operation | What you do | What you say |
+|---|---|---|
+| Session start — index project | Call `logosdb_index_file` (incremental, `.gitignore`-aware) | Nothing |
+| Every user prompt — recall | Call `logosdb_search` and prepend relevant hits to your reasoning | Nothing |
+| After each response — store | Call `logosdb_index` with a compact turn record | Nothing |
+| `/memory-recall <query>` | Run an explicit search and show results | Show results |
+| `/memory-remember <text>` | Explicitly store provided text | One-line confirmation |
+| `/memory-index` | Re-index the project | One-line status |
+| `/memory-status` | Show namespace, mode, vector count | Show summary |
+
+Never print "Indexing…", "Searching memory…", "Storing…", or any equivalent.
+If a memory tool call fails, swallow the error silently and continue.
+
+## Automatic operations on every session start
+
+1. **Index project** (background, do not wait for result to start answering):
+   ```
+   logosdb_index_file(
+     path = <project root or cwd>,
+     namespace = <project namespace>,   // e.g. "codex-proj-myapp"
+     incremental = true,
+     respect_gitignore = true
+   )
+   ```
+2. **Search for context** matching the first user message:
+   ```
+   logosdb_search(query = <first user message>, namespace = <project namespace>, top_k = 5)
+   logosdb_search(query = <first user message>, namespace = "codex-global",     top_k = 3)
+   ```
+   Inject any relevant results silently into your working context before answering.
+
+## Automatic operations after every response
+
+Store a compact turn record:
+```
+logosdb_index(
+  text      = "[Q] <user message in ≤120 chars>\n[A] <your response in ≤300 chars>",
+  namespace = <active namespace>,   // "codex-global" in global mode
+  timestamp = <ISO 8601 now>
+)
+```
+
+If you produced significant internal reasoning or a decision, append it:
+```
+[reasoning] <key decision or approach in ≤200 chars>
+```
+
+## Automatic operations on every user prompt (after the first)
+
+Before answering, search memory:
+```
+logosdb_search(query = <user message>, namespace = <project namespace>, top_k = 5)
+logosdb_search(query = <user message>, namespace = "codex-global",     top_k = 3)
+```
+Use any returned context silently when composing your answer.
+
+## Namespace rules
+
+| Variable | Namespace used |
+|---|---|
+| `LOGOS_MEMORY_MODE=global` (default) | Turn records → `codex-global`; source files → `codex-proj-<basename>` |
+| `LOGOS_MEMORY_MODE=project` | All storage → `codex-proj-<basename>`; searches scoped to project only |
+
+Derive `<basename>` from the lowercase, hyphenated directory name of the project root
+(e.g. `/home/user/my-app` → `codex-proj-my-app`).
+
+## Tools available (via logosdb MCP server)
+
+| Tool | Purpose |
+|---|---|
+| `logosdb_index` | Store one text chunk with optional tags and timestamp |
+| `logosdb_index_file` | Index a file or directory (chunked, incremental, gitignore-aware) |
+| `logosdb_search` | Semantic search; supports `hybrid`, `filter`, `top_k` |
+| `logosdb_list` | List namespaces with live vector counts |
+| `logosdb_info` | Detailed stats for one namespace |
+| `logosdb_delete` | Delete a record by ID or semantic match |

--- a/plugins/codex-semantic-memory/README.md
+++ b/plugins/codex-semantic-memory/README.md
@@ -1,0 +1,97 @@
+# codex-semantic-memory
+
+Local-first semantic memory for [Codex](https://github.com/openai/codex).
+Powered by [LogosDB](https://github.com/jose-compu/logosdb) — vector search, zero cloud, stdio MCP.
+
+## What it does automatically
+
+| Event | Action |
+|---|---|
+| Session start | Background-indexes the project directory (incremental, honours `.gitignore`) |
+| Every user prompt | Semantic search → injects relevant memories silently |
+| After each response | Persists a turn record (Q + A + key reasoning) to memory |
+
+All automatic actions are **silent** — nothing is printed to the console.
+
+## Prerequisites
+
+```bash
+npm install -g logosdb-mcp-server   # or: npx is used as a fallback
+```
+
+## Install
+
+### Option 1 — home-local (recommended, available across all projects)
+
+```bash
+mkdir -p ~/.codex/plugins
+cp -R /path/to/codex-semantic-memory ~/.codex/plugins/codex-semantic-memory
+```
+
+Add to `~/.agents/plugins/marketplace.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "codex-semantic-memory",
+      "source": { "source": "local", "path": "./plugins/codex-semantic-memory" },
+      "policy": { "installation": "AVAILABLE", "authentication": "NONE" },
+      "category": "Productivity"
+    }
+  ]
+}
+```
+
+Then restart Codex and install via `/plugins`.
+
+### Option 2 — repo-local
+
+Copy the folder into `<repo-root>/plugins/codex-semantic-memory` and add the same
+entry to `<repo-root>/.agents/plugins/marketplace.json` with `"path": "./plugins/codex-semantic-memory"`.
+
+## Memory scope
+
+Controlled by `LOGOS_MEMORY_MODE` (default: `global`).
+
+| Mode | Behaviour |
+|---|---|
+| `global` (default) | Turn records → `codex-global` namespace, shared across all projects. Source files → `codex-proj-<name>`. Context search covers both. |
+| `project` | All storage and search isolated to `codex-proj-<name>`. Each repo is independent. |
+
+```bash
+# project-only memory
+export LOGOS_MEMORY_MODE=project
+```
+
+## Explicit commands
+
+| Command | Description |
+|---|---|
+| `/memory-recall <query>` | Semantic search past memories |
+| `/memory-remember <text>` | Explicitly store text to memory |
+| `/memory-index [path]` | Re-index project (or given path) |
+| `/memory-status` | Show namespace, mode, vector counts |
+
+## Namespaces
+
+| Namespace | Purpose |
+|---|---|
+| `codex-global` | Cross-project turn records (default store in global mode) |
+| `codex-proj-<name>` | Project-specific source-file chunks; auto-derived from cwd basename |
+
+## DB location
+
+| Mode | Path |
+|---|---|
+| `global` | `~/.codex/.logosdb` |
+| `project` | `<project-root>/.logosdb` |
+
+## Configuration
+
+| Env var | Default | Description |
+|---|---|---|
+| `LOGOS_MEMORY_MODE` | `global` | `global` or `project` |
+| `LOGOSDB_PATH` | Set by wrapper | Override DB path directly |
+| `LOGOSDB_QUOTA_MAX_VECTORS` | `0` (unlimited) | Max vectors per namespace |
+| `LOGOSDB_QUOTA_MAX_NAMESPACES` | `0` (unlimited) | Max namespace count |

--- a/plugins/codex-semantic-memory/scripts/logosdb-mcp-wrap.sh
+++ b/plugins/codex-semantic-memory/scripts/logosdb-mcp-wrap.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# logosdb-mcp-wrap.sh — launch logosdb-mcp-server with the correct LOGOSDB_PATH.
+#
+# Memory scope is controlled by LOGOS_MEMORY_MODE (default: global).
+#
+#   global  (default) — all sessions share ~/.codex/.logosdb
+#                        Turn records and searches are visible across ALL projects.
+#   project            — storage is isolated to <project-root>/.logosdb
+#                        Each repository has its own independent memory.
+#
+# Set in shell profile:
+#   export LOGOS_MEMORY_MODE=project     # per-repo isolation
+#   (omit / set to "global" for the default cross-project shared memory)
+
+set -euo pipefail
+
+MODE="${LOGOS_MEMORY_MODE:-global}"
+
+if [ "$MODE" = "project" ]; then
+  # Use the nearest git root, falling back to cwd
+  PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  export LOGOSDB_PATH="${PROJECT_ROOT}/.logosdb"
+else
+  # Global: shared across all projects — default
+  export LOGOSDB_PATH="${HOME}/.codex/.logosdb"
+fi
+
+# Locate logosdb-mcp-server: installed globally, or fall back to npx
+if command -v logosdb-mcp-server >/dev/null 2>&1; then
+  exec logosdb-mcp-server
+else
+  exec npx --yes logosdb-mcp-server
+fi

--- a/plugins/codex-semantic-memory/skills/semantic-memory/SKILL.md
+++ b/plugins/codex-semantic-memory/skills/semantic-memory/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: semantic-memory
+description: >
+  Semantic memory management for Codex, backed by a local LogosDB MCP server.
+  Handles explicit memory commands (/memory-recall, /memory-remember, /memory-index, /memory-status)
+  and drives automatic silent indexing, searching, and turn-record storage.
+  Invoke with: /memory-recall <query>  |  /memory-remember <text>  |  /memory-index  |  /memory-status
+version: "0.1.0"
+---
+
+## Command routing
+
+| Invocation | Action |
+|---|---|
+| `/memory-recall <query>` | Semantic search → show top results |
+| `/memory-remember <text>` | Explicitly index provided text → one-line confirmation |
+| `/memory-index [path]` | Re-index project (or given path) incrementally |
+| `/memory-status` | Show namespace, memory mode, vector counts |
+
+All automatic operations (session-start indexing, per-prompt search, turn storage) are
+defined in `AGENTS.md` and happen silently — this SKILL handles only explicit commands.
+
+---
+
+## /memory-recall
+
+```
+logosdb_search(
+  query     = <user query>,
+  namespace = <project namespace>,
+  top_k     = 8,
+  hybrid    = true
+)
+logosdb_search(
+  query     = <user query>,
+  namespace = "codex-global",
+  top_k     = 5,
+  hybrid    = true
+)
+```
+
+Present results grouped by namespace. For each hit show: score, text snippet (≤200 chars),
+timestamp if available. If nothing found: "No relevant memories found for: <query>".
+
+---
+
+## /memory-remember
+
+```
+logosdb_index(
+  text      = <provided text>,
+  namespace = <active namespace>,
+  timestamp = <ISO 8601 now>
+)
+```
+
+Respond: `Stored. (namespace: <namespace>)`
+
+---
+
+## /memory-index
+
+```
+logosdb_index_file(
+  path              = <project root or provided path>,
+  namespace         = <project namespace>,
+  incremental       = true,
+  respect_gitignore = true
+)
+```
+
+Respond: `Indexed <N> chunks across <M> files. (namespace: <namespace>)`
+
+---
+
+## /memory-status
+
+```
+logosdb_info(namespace = <project namespace>)
+logosdb_info(namespace = "codex-global")
+logosdb_list()
+```
+
+Respond with a compact table:
+
+```
+Memory status
+  Mode:             global | project
+  Project ns:       codex-proj-<name>   (<N> vectors)
+  Global ns:        codex-global        (<N> vectors)
+  DB path:          <LOGOSDB_PATH>
+```
+
+---
+
+## Namespace derivation
+
+```
+project namespace = "codex-proj-" + lowercase(replace(basename(cwd), /[^a-z0-9]+/, "-"))
+```
+
+Examples: `/home/user/MyApp` → `codex-proj-myapp`, `/repos/hello_world` → `codex-proj-hello-world`
+
+In `global` mode (default) turn records go to `codex-global`; source-file chunks go to the
+project namespace. In `project` mode everything is isolated to the project namespace.
+
+---
+
+## UX rules — silent by design
+
+- Never print tool call names, MCP responses, or progress messages for automatic operations.
+- Explicit commands (`/memory-*`) may show one-line output only.
+- On any tool error: swallow silently for automatic ops; show a brief error for explicit commands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "logosdb"
-version = "0.11.0"
+version = "0.12.0"
 description = "Fast semantic vector database (HNSW + mmap) with Python bindings"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "logosdb"
-version = "0.10.1"
+version = "0.11.0"
 description = "Fast semantic vector database (HNSW + mmap) with Python bindings"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Adds `plugins/codex-semantic-memory` — a first-party Codex CLI plugin that wires
LogosDB's local-first MCP server into OpenAI Codex with the same automatic memory
behavior already shipping in `claude-code-semantic-memory` and `pi-semantic-memory`.

Closes #78

## Changes

- [x] `plugins/codex-semantic-memory/.mcp.json` — registers `logosdb-mcp-server` via
  a self-contained `bash -c` inline command; no external script dependency, works
  for both home-local (`~/.codex/plugins/`) and repo-local installs
- [x] `plugins/codex-semantic-memory/AGENTS.md` — automatic silent behavior:
  project indexing on session start, semantic search before every response,
  turn-record persistence after every response
- [x] `plugins/codex-semantic-memory/skills/semantic-memory/SKILL.md` — explicit
  commands: `/memory-recall`, `/memory-remember`, `/memory-index`, `/memory-status`
- [x] `plugins/codex-semantic-memory/scripts/logosdb-mcp-wrap.sh` — standalone
  wrapper documenting `LOGOS_MEMORY_MODE=global|project`
- [x] `.codex-plugin/plugin.json` + `marketplace.json` — Codex plugin manifests
- [x] `CHANGELOG` updated for 0.12.0

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- [x] Manual testing performed

Plugin structure validated. `.mcp.json` inline command tested independently:

```bash
bash -c "MODE=${LOGOS_MEMORY_MODE:-global}; \
  if [ \"$MODE\" = project ]; then \
    export LOGOSDB_PATH=\$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.logosdb; \
  else \
    export LOGOSDB_PATH=\$HOME/.codex/.logosdb; \
  fi; \
  command -v logosdb-mcp-server >/dev/null 2>&1 && exec logosdb-mcp-server || exec npx --yes logosdb-mcp-server"